### PR TITLE
Swift 6 compatibility and macOS 26 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ Closures, Combine framework, networking (URLSession), OOP patterns (protocols, g
 
 ## Requirements
 
-- Xcode 14+
-- Swift 5.7+
-- macOS
+- Xcode 26+
+- Swift 6+
+- macOS 26+

--- a/SwiftChallenges/Lab/swift/file/FileOpener.swift
+++ b/SwiftChallenges/Lab/swift/file/FileOpener.swift
@@ -74,7 +74,7 @@ public class FileOpener {
             // Then reading it back from the file
             var inString = ""
             do {
-                inString = try String(contentsOf: fileURL)
+                inString = try String(contentsOf: fileURL, encoding: .utf8)
             } catch {
                 print("Failed reading from URL: \(fileURL), Error: " + error.localizedDescription)
             }


### PR DESCRIPTION
## Summary
- Fix deprecated `String(contentsOf:)` in `FileOpener.swift` — updated to `String(contentsOf:encoding:)` to resolve macOS 15+ deprecation warning
- Update README requirements to reflect Swift 6 and macOS 26 minimum deployment target
- Verified clean build under Swift 6 language mode with zero errors and zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)