### PR TITLE
Add LongestRepeatingCharacterReplacement sliding window solution and tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -2089,8 +2089,8 @@
 		FBB267572F9594C300CF0DB9 /* SlidingWindow */ = {
 			isa = PBXGroup;
 			children = (
-				FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */,
 				FBB2675F2F959B2100CF0DB9 /* LengthOfLongestSubstringTest.swift */,
+				FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */,
 				FBB267582F9594EB00CF0DB9 /* MaxProfitTest.swift */,
 				FBB267662F95F21000CF0DB9 /* MinimumWindowSubstringTest.swift */,
 			);

--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -594,6 +594,9 @@
 		DEE62553283C5467003EC784 /* PageTurnCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62552283C5467003EC784 /* PageTurnCount.swift */; };
 		DEE62554283C5467003EC784 /* PageTurnCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62552283C5467003EC784 /* PageTurnCount.swift */; };
 		DEE62556283C5499003EC784 /* PageTurnCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62555283C5499003EC784 /* PageTurnCountTest.swift */; };
+		FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
+		FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
+		FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */; };
 		FBB2674F2F9488F100CF0DB9 /* LongestConsecutive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB2674E2F9488F100CF0DB9 /* LongestConsecutive.swift */; };
 		FBB267502F9488F100CF0DB9 /* LongestConsecutive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB2674E2F9488F100CF0DB9 /* LongestConsecutive.swift */; };
 		FBB267522F94892E00CF0DB9 /* LongestConsecutiveTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB267512F94892E00CF0DB9 /* LongestConsecutiveTest.swift */; };
@@ -1005,6 +1008,8 @@
 		DEE62550283B4DA2003EC784 /* SocksMatchTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocksMatchTest.swift; sourceTree = "<group>"; };
 		DEE62552283C5467003EC784 /* PageTurnCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTurnCount.swift; sourceTree = "<group>"; };
 		DEE62555283C5499003EC784 /* PageTurnCountTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PageTurnCountTest.swift; path = SwiftChallenges/Lab/HackerRank/PageTurnCountTest.swift; sourceTree = SOURCE_ROOT; };
+		FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacement.swift; sourceTree = "<group>"; };
+		FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacementTest.swift; sourceTree = "<group>"; };
 		FBB2674E2F9488F100CF0DB9 /* LongestConsecutive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestConsecutive.swift; sourceTree = "<group>"; };
 		FBB267512F94892E00CF0DB9 /* LongestConsecutiveTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LongestConsecutiveTest.swift; path = SwiftChallenges/Lab/collections/LongestConsecutiveTest.swift; sourceTree = SOURCE_ROOT; };
 		FBB267542F95948300CF0DB9 /* MaxProfit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxProfit.swift; sourceTree = "<group>"; };
@@ -2076,6 +2081,7 @@
 				FBB2675A2F959AD000CF0DB9 /* LengthOfLongestSubstring.swift */,
 				FBB267542F95948300CF0DB9 /* MaxProfit.swift */,
 				FBB267612F95F19500CF0DB9 /* MinimumWindowSubstring.swift */,
+				FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */,
 			);
 			path = SlidingWindow;
 			sourceTree = "<group>";
@@ -2083,6 +2089,7 @@
 		FBB267572F9594C300CF0DB9 /* SlidingWindow */ = {
 			isa = PBXGroup;
 			children = (
+				FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */,
 				FBB2675F2F959B2100CF0DB9 /* LengthOfLongestSubstringTest.swift */,
 				FBB267582F9594EB00CF0DB9 /* MaxProfitTest.swift */,
 				FBB267662F95F21000CF0DB9 /* MinimumWindowSubstringTest.swift */,
@@ -2349,6 +2356,7 @@
 				DECCEFE327FCFB99007BA99C /* MergeSort.swift in Sources */,
 				DE4B8F61289B23F100DF9D4C /* LuckyTicket.swift in Sources */,
 				DECCEEA327FCF8B4007BA99C /* Person.swift in Sources */,
+				FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */,
 				DECCEE8427FCF8B4007BA99C /* RandomNumber.swift in Sources */,
 				DECCEE7727FCF8B4007BA99C /* LargestMissingNumber.swift in Sources */,
 				DEA5C1CB282B24C2004AE296 /* MilitaryTime.swift in Sources */,
@@ -2454,6 +2462,7 @@
 				DECCF06727FCFEE3007BA99C /* CharacterCaseConversion.swift in Sources */,
 				DEC3D7C6287E384400EB14F8 /* BSTModeTest.swift in Sources */,
 				DECCF02F27FCFC36007BA99C /* LinkedListTest.swift in Sources */,
+				FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */,
 				DECCEFBA27FCFA7F007BA99C /* LinkedList.swift in Sources */,
 				DEDB4957283DF8A000B2238B /* UtopianTreeTest.swift in Sources */,
 				DE71A33228208E930003DD95 /* BSTAverageLevel.swift in Sources */,
@@ -2556,6 +2565,7 @@
 				DECCF00727FCFBD3007BA99C /* Direction.swift in Sources */,
 				DE71A3372820A6960003DD95 /* MaximumPopulationYear.swift in Sources */,
 				DECCEEAD27FCF8DA007BA99C /* Palindrome.swift in Sources */,
+				FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */,
 				DED79618284F1C93005EF2E7 /* BSTLowestCommonAncestor.swift in Sources */,
 				DECCEF8F27FCF9C1007BA99C /* AnagramTest.swift in Sources */,
 				DECCEECC27FCF942007BA99C /* DaysOfYear.swift in Sources */,

--- a/SwiftChallenges/Lab/SlidingWindow/LongestRepeatingCharacterReplacement.swift
+++ b/SwiftChallenges/Lab/SlidingWindow/LongestRepeatingCharacterReplacement.swift
@@ -19,14 +19,13 @@ class LongestRepeatingCharacterReplacement {
 
             // replacements needed = window size - count of the most frequent char
             // if that exceeds k, the window is invalid — shrink from the left
-            let currentWindow = r - l + 1
-            while currentWindow - (frequency.values.max() ?? 0) > k {
+            while r - l + 1 - (frequency.values.max() ?? 0) > k {
                 frequency[S[l], default: 0] -= 1
                 l += 1
             }
 
             // window is now valid; record its length
-            res = max(res, currentWindow)
+            res = max(res, r - l + 1)
         }
         return res
     }
@@ -46,7 +45,6 @@ class LongestRepeatingCharacterReplacement {
             // if the window is invalid, shift it right by one (never shrink — window only grows)
             // maxFrequency may be stale but that's fine: a stale high value just means we don't
             // grow until a char catches up, which is correct
-
             if (r - l + 1) - maxFrequency > k {
                 frequency[S[l], default: 0] -= 1
                 l += 1

--- a/SwiftChallenges/Lab/SlidingWindow/LongestRepeatingCharacterReplacement.swift
+++ b/SwiftChallenges/Lab/SlidingWindow/LongestRepeatingCharacterReplacement.swift
@@ -1,0 +1,60 @@
+//
+//  LongestRepeatingCharacterReplacement.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 4/25/26.
+//  https://leetcode.com/problems/longest-repeating-character-replacement/
+
+class LongestRepeatingCharacterReplacement {
+    
+    func characterReplacement(_ s: String, _ k: Int) -> Int {
+        var res = 0
+        var frequency: [Character: Int] = [:] // count of each char in the current window
+        var l = 0
+        let S = Array(s)
+
+        for r in S.indices {
+            // expand window by including S[r]
+            frequency[S[r], default: 0] += 1
+
+            // replacements needed = window size - count of the most frequent char
+            // if that exceeds k, the window is invalid — shrink from the left
+            let currentWindow = r - l + 1
+            while currentWindow - (frequency.values.max() ?? 0) > k {
+                frequency[S[l], default: 0] -= 1
+                l += 1
+            }
+
+            // window is now valid; record its length
+            res = max(res, currentWindow)
+        }
+        return res
+    }
+    
+    func characterReplacementV2(_ s: String, _ k: Int) -> Int {
+        var res = 0
+        var frequency: [Character: Int] = [:] // count of each char in the current window
+        var l = 0
+        let S = Array(s)
+        var maxFrequency: Int = 0
+
+        for r in S.indices {
+            // expand window and track the highest frequency seen so far
+            frequency[S[r], default: 0] += 1
+            maxFrequency = max(maxFrequency, frequency[S[r], default: 0])
+
+            // if the window is invalid, shift it right by one (never shrink — window only grows)
+            // maxFrequency may be stale but that's fine: a stale high value just means we don't
+            // grow until a char catches up, which is correct
+
+            if (r - l + 1) - maxFrequency > k {
+                frequency[S[l], default: 0] -= 1
+                l += 1
+            }
+
+            // window is now valid; record its length
+            res = max(res, r - l + 1)
+        }
+        return res
+    }
+}

--- a/SwiftChallengesTests/Lab/SlidingWindow/LongestRepeatingCharacterReplacementTest.swift
+++ b/SwiftChallengesTests/Lab/SlidingWindow/LongestRepeatingCharacterReplacementTest.swift
@@ -1,0 +1,8 @@
+//
+//  LongestRepeatingCharacterReplacementTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 4/25/26.
+//
+
+import Foundation

--- a/SwiftChallengesTests/Lab/SlidingWindow/LongestRepeatingCharacterReplacementTest.swift
+++ b/SwiftChallengesTests/Lab/SlidingWindow/LongestRepeatingCharacterReplacementTest.swift
@@ -5,4 +5,23 @@
 //  Created by KyleLearnedThis on 4/25/26.
 //
 
-import Foundation
+import XCTest
+
+class LongestRepeatingCharacterReplacementTest: XCTestCase {
+    let challenge = LongestRepeatingCharacterReplacement()
+    func testBasic01() {
+        let input = "ABAB"
+        let k = 2
+        let expected: Int = 4
+        let actual = challenge.characterReplacement(input, k)
+        XCTAssertEqual(actual, expected)
+    }
+    
+    func testBasic02() {
+        let input = "AABABBA"
+        let k = 1
+        let expected: Int = 4
+        let actual = challenge.characterReplacement(input, k)
+        XCTAssertEqual(actual, expected)
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `characterReplacement` using a sliding window with `frequency.values.max()` to track the most frequent char
- Adds `characterReplacementV2` with an optimized O(1) `maxFrequency` tracker, replacing `while` with `if` since the window only ever grows
- Adds test cases for both LeetCode examples

## Test plan
- [x] `testBasic01`: "ABAB", k=2 → 4
- [x] `testBasic02`: "AABABBA", k=1 → 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)