### PR TITLE
Add ContinuousSubarraySum solution and unit tests (#108)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -594,6 +594,9 @@
 		DEE62553283C5467003EC784 /* PageTurnCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62552283C5467003EC784 /* PageTurnCount.swift */; };
 		DEE62554283C5467003EC784 /* PageTurnCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62552283C5467003EC784 /* PageTurnCount.swift */; };
 		DEE62556283C5499003EC784 /* PageTurnCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62555283C5499003EC784 /* PageTurnCountTest.swift */; };
+		FB1DFB7E2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
+		FB1DFB7F2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
+		FB1DFB812FCFD98D00692126 /* ContinuousSubarraySumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */; };
 		FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */; };
@@ -1058,6 +1061,8 @@
 		DEE62550283B4DA2003EC784 /* SocksMatchTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocksMatchTest.swift; sourceTree = "<group>"; };
 		DEE62552283C5467003EC784 /* PageTurnCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTurnCount.swift; sourceTree = "<group>"; };
 		DEE62555283C5499003EC784 /* PageTurnCountTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PageTurnCountTest.swift; path = SwiftChallenges/Lab/HackerRank/PageTurnCountTest.swift; sourceTree = SOURCE_ROOT; };
+		FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySum.swift; sourceTree = "<group>"; };
+		FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySumTest.swift; sourceTree = "<group>"; };
 		FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacement.swift; sourceTree = "<group>"; };
 		FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacementTest.swift; sourceTree = "<group>"; };
 		FB49A3812F9D8D140013680A /* TwoSum2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoSum2.swift; sourceTree = "<group>"; };
@@ -2272,6 +2277,7 @@
 		FB774C012FA997BD00B1DC28 /* PrefixSum */ = {
 			isa = PBXGroup;
 			children = (
+				FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */,
 				FB774C0E2FAAE5AB00B1DC28 /* ProductArrayExceptSelfTest.swift */,
 				FB774C092FA998C300B1DC28 /* RangeSumQueryTest.swift */,
 			);
@@ -2281,8 +2287,9 @@
 		FB774C052FA9983300B1DC28 /* PrefixSum */ = {
 			isa = PBXGroup;
 			children = (
-				FB774C062FA998A100B1DC28 /* RangeSumQuery.swift */,
+				FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */,
 				FB774C0B2FAAE53700B1DC28 /* ProductArrayExceptSelf.swift */,
+				FB774C062FA998A100B1DC28 /* RangeSumQuery.swift */,
 			);
 			path = PrefixSum;
 			sourceTree = "<group>";
@@ -2471,6 +2478,7 @@
 				DECCEE9C27FCF8B4007BA99C /* EnvironmentFetch.swift in Sources */,
 				DECCF04A27FCFE49007BA99C /* UnivaluedBinaryTree.swift in Sources */,
 				DECCEEA027FCF8B4007BA99C /* Phone.swift in Sources */,
+				FB1DFB7E2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */,
 				DECCF05827FCFE49007BA99C /* MergeTwoBST.swift in Sources */,
 				DE1CA2FF27FEDCA7001D8BD1 /* PrintTriangle.swift in Sources */,
 				DE2E0F8F280EBF44006D06FA /* BattleshipProbability.swift in Sources */,
@@ -2758,6 +2766,7 @@
 				DECCEEBB27FCF922007BA99C /* RankTransformArray.swift in Sources */,
 				DECCEEB427FCF8EB007BA99C /* CountNegativeMatrix.swift in Sources */,
 				DECA9DE728C8188000E88CCD /* BoxBlur.swift in Sources */,
+				FB1DFB812FCFD98D00692126 /* ContinuousSubarraySumTest.swift in Sources */,
 				DECCF03027FCFC36007BA99C /* EratosthenesSieveTest.swift in Sources */,
 				DECCEEE027FCF96B007BA99C /* BasicPair.swift in Sources */,
 				DECCEE1927FCF848007BA99C /* NumberToBinaryTest.swift in Sources */,
@@ -2873,6 +2882,7 @@
 				DEA5C1CF282B254D004AE296 /* MilitaryTimeTest.swift in Sources */,
 				DECCEEDE27FCF966007BA99C /* Phone.swift in Sources */,
 				DED795C8284DE7DA005EF2E7 /* BaseOrderedMap.swift in Sources */,
+				FB1DFB7F2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */,
 				DECCEEE327FCF973007BA99C /* ComputeClosure.swift in Sources */,
 				DECCEF6627FCF9C1007BA99C /* DestinationCityTest.swift in Sources */,
 				DE15998528B6D0530081E2BE /* ArithmeticSubArraysTest.swift in Sources */,

--- a/SwiftChallenges/NeetCode/PrefixSum/ContinuousSubarraySum.swift
+++ b/SwiftChallenges/NeetCode/PrefixSum/ContinuousSubarraySum.swift
@@ -1,0 +1,33 @@
+//
+//  ContinuousSubarraySum.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/2/26.
+//  https://leetcode.com/problems/continuous-subarray-sum/
+
+class ContinuousSubarraySum {
+    // Returns true if any subarray of length >= 2 sums to a multiple of k.
+    // Approach: if two prefix sums share the same remainder mod k, the subarray
+    // between them is divisible by k (their difference cancels the remainder).
+    func checkSubarraySum(_ nums: [Int], _ k: Int) -> Bool {
+        // Maps remainder -> earliest index it was seen.
+        // Seeded with 0: -1 so a prefix sum divisible by k from index 0 is handled.
+        var remainder = [0: -1]
+        var total = 0
+
+        for (i, n) in nums.enumerated() {
+            total += n
+            let r = total % k
+
+            if remainder[r] == nil {
+                // First time seeing this remainder — record the index.
+                remainder[r] = i
+            } else if i - remainder[r]! > 1 {
+                // Same remainder seen before, and the subarray between is length >= 2.
+                return true
+            }
+            // If the gap is <= 1 we skip — subarray must have at least 2 elements.
+        }
+        return false
+    }
+}

--- a/SwiftChallengesTests/NeetCode/PrefixSum/ContinuousSubarraySumTest.swift
+++ b/SwiftChallengesTests/NeetCode/PrefixSum/ContinuousSubarraySumTest.swift
@@ -1,0 +1,62 @@
+//
+//  ContinuousSubarraySumTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/2/26.
+//
+
+import XCTest
+
+class ContinuousSubarraySumTest: XCTestCase {
+    let solution = ContinuousSubarraySum()
+
+    // [2, 4] sums to 6, which is divisible by 6
+    func testExample1() {
+        XCTAssertTrue(solution.checkSubarraySum([23, 2, 4, 6, 7], 6))
+    }
+
+    // [2, 6, 4, 7] sums to 19... actually [6, 4, 7] = 17... [23, 2, 6] = 31... [2, 6, 4] = 12, divisible by 6
+    func testExample2() {
+        XCTAssertTrue(solution.checkSubarraySum([23, 2, 6, 4, 7], 6))
+    }
+
+    // No subarray of length >= 2 sums to a multiple of 13
+    func testNoMatch() {
+        XCTAssertFalse(solution.checkSubarraySum([23, 2, 6, 4, 7], 13))
+    }
+
+    // Minimum valid case: [1, 5] sums to 6, divisible by 6
+    func testTwoElementsMatch() {
+        XCTAssertTrue(solution.checkSubarraySum([1, 5], 6))
+    }
+
+    // [1, 5] sums to 6, not divisible by 4
+    func testTwoElementsNoMatch() {
+        XCTAssertFalse(solution.checkSubarraySum([1, 5], 4))
+    }
+
+    // [0, 0] sums to 0, which is divisible by any k (0 % k == 0)
+    func testAllZeros() {
+        XCTAssertTrue(solution.checkSubarraySum([0, 0], 5))
+    }
+
+    // k == 1: every integer is divisible by 1, so any subarray of length >= 2 qualifies
+    func testKEqualsOne() {
+        XCTAssertTrue(solution.checkSubarraySum([1, 2, 3], 1))
+    }
+
+    // k larger than the total sum — no subarray can reach a multiple of 100
+    func testLargeK() {
+        XCTAssertFalse(solution.checkSubarraySum([1, 2], 100))
+    }
+
+    // [1, 5, 3] = 9, [5, 3] = 8 — match is not at the start or end
+    func testMatchInMiddle() {
+        XCTAssertTrue(solution.checkSubarraySum([1, 5, 3, 2, 7], 8))
+    }
+
+    // [1, 2, 3] sums to exactly k=6, the whole array is the matching subarray
+    func testExactSumEqualsK() {
+        XCTAssertTrue(solution.checkSubarraySum([1, 2, 3], 6))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ContinuousSubarraySum` solution using prefix sum + remainder hash map approach
- Adds unit tests covering examples, edge cases (zeros, k=1, large k, exact sum)
- Updates Xcode project file to include new source files

## Test plan
- [x] Build succeeds
- [x] All `ContinuousSubarraySumTest` cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)