### PR TITLE
Add SubarraySumEqualsK solution and unit tests (#109)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -597,6 +597,9 @@
 		FB1DFB7E2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB7F2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB812FCFD98D00692126 /* ContinuousSubarraySumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */; };
+		FB2C5DA82FD3FB2B009550A1 /* SubarraySumEqualsK.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */; };
+		FB2C5DA92FD3FB2B009550A1 /* SubarraySumEqualsK.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */; };
+		FB2C5DAB2FD3FB8E009550A1 /* SubarraySumEqualsKTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DAA2FD3FB8E009550A1 /* SubarraySumEqualsKTest.swift */; };
 		FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */; };
@@ -1063,6 +1066,8 @@
 		DEE62555283C5499003EC784 /* PageTurnCountTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PageTurnCountTest.swift; path = SwiftChallenges/Lab/HackerRank/PageTurnCountTest.swift; sourceTree = SOURCE_ROOT; };
 		FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySum.swift; sourceTree = "<group>"; };
 		FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySumTest.swift; sourceTree = "<group>"; };
+		FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubarraySumEqualsK.swift; sourceTree = "<group>"; };
+		FB2C5DAA2FD3FB8E009550A1 /* SubarraySumEqualsKTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubarraySumEqualsKTest.swift; sourceTree = "<group>"; };
 		FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacement.swift; sourceTree = "<group>"; };
 		FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacementTest.swift; sourceTree = "<group>"; };
 		FB49A3812F9D8D140013680A /* TwoSum2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoSum2.swift; sourceTree = "<group>"; };
@@ -2277,6 +2282,7 @@
 		FB774C012FA997BD00B1DC28 /* PrefixSum */ = {
 			isa = PBXGroup;
 			children = (
+				FB2C5DAA2FD3FB8E009550A1 /* SubarraySumEqualsKTest.swift */,
 				FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */,
 				FB774C0E2FAAE5AB00B1DC28 /* ProductArrayExceptSelfTest.swift */,
 				FB774C092FA998C300B1DC28 /* RangeSumQueryTest.swift */,
@@ -2290,6 +2296,7 @@
 				FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */,
 				FB774C0B2FAAE53700B1DC28 /* ProductArrayExceptSelf.swift */,
 				FB774C062FA998A100B1DC28 /* RangeSumQuery.swift */,
+				FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */,
 			);
 			path = PrefixSum;
 			sourceTree = "<group>";
@@ -2374,7 +2381,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1330;
-				LastUpgradeCheck = 2620;
+				LastUpgradeCheck = 2650;
 				TargetAttributes = {
 					DECCEDF627FCF814007BA99C = {
 						CreatedOnToolsVersion = 13.3;
@@ -2554,6 +2561,7 @@
 				DECCEE8027FCF8B4007BA99C /* MedianOfTwoSortedArrays.swift in Sources */,
 				DEC3D828287EC21A00EB14F8 /* RobotOrigin.swift in Sources */,
 				DECCF07627FCFEE3007BA99C /* NumberOfJewelsInStones.swift in Sources */,
+				FB2C5DA92FD3FB2B009550A1 /* SubarraySumEqualsK.swift in Sources */,
 				DE2E0F9B280FEF7E006D06FA /* KaitenzushiPuzzle.swift in Sources */,
 				DE221EE82819473800CAE40D /* SimpleLinkedList.swift in Sources */,
 				DECCEE9227FCF8B4007BA99C /* LongestCommonPrefix.swift in Sources */,
@@ -2977,6 +2985,7 @@
 				DECCF08F27FD90AA007BA99C /* SortingSentenceTest.swift in Sources */,
 				FB49A3962F9EC7770013680A /* TrappingRainWaterTest.swift in Sources */,
 				DE1CA2FB27FED90A001D8BD1 /* NumberPlusMinusTeest.swift in Sources */,
+				FB2C5DAB2FD3FB8E009550A1 /* SubarraySumEqualsKTest.swift in Sources */,
 				DECCEF9B27FCF9C1007BA99C /* RansomNotesTest.swift in Sources */,
 				DE71A3392820A7060003DD95 /* MaximumPopulationYearTest.swift in Sources */,
 				DECCEEB227FCF8E6007BA99C /* TopKElements.swift in Sources */,
@@ -2997,6 +3006,7 @@
 				DECCF02E27FCFC36007BA99C /* DijkstraTest.swift in Sources */,
 				FB774C0A2FA998C300B1DC28 /* RangeSumQueryTest.swift in Sources */,
 				DECD6262286B049F000221F6 /* MaximumFrequencyStack.swift in Sources */,
+				FB2C5DA82FD3FB2B009550A1 /* SubarraySumEqualsK.swift in Sources */,
 				DE4B8F67289B2BE400DF9D4C /* ReverseParentheses.swift in Sources */,
 				DECCEF8927FCF9C1007BA99C /* SortDictionaryExampleTest.swift in Sources */,
 				DE71A31D281F92530003DD95 /* PartitionEqualSum.swift in Sources */,
@@ -3103,6 +3113,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -3169,6 +3180,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";

--- a/SwiftChallenges.xcodeproj/xcshareddata/xcschemes/SwiftChallenges.xcscheme
+++ b/SwiftChallenges.xcodeproj/xcshareddata/xcschemes/SwiftChallenges.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2650"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftChallenges/NeetCode/PrefixSum/SubarraySumEqualsK.swift
+++ b/SwiftChallenges/NeetCode/PrefixSum/SubarraySumEqualsK.swift
@@ -1,0 +1,33 @@
+//
+//  SubarraySumEqualsK.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/5/26.
+//  https://leetcode.com/problems/subarray-sum-equals-k/
+
+class SubarraySumEqualsK {
+    func subarraySum(_ nums: [Int], _ k: Int) -> Int {
+        var count = 0
+        var runningSum = 0
+
+        // key: prefix sum value, value: how many times we've seen it
+        // seed with 0:1 so subarrays starting at index 0 are handled
+        var seenPrefixSums = [0: 1]
+
+        for num in nums {
+            runningSum += num
+
+            // what prefix sum do we need to have seen in the past
+            // so that (runningSum - pastSum) == k?
+            let neededPastSum = runningSum - k
+
+            // each time that past prefix sum appeared is a valid subarray ending here
+            count += seenPrefixSums[neededPastSum, default: 0]
+
+            // record that we've now seen this prefix sum
+            seenPrefixSums[runningSum, default: 0] += 1
+        }
+
+        return count
+    }
+}

--- a/SwiftChallengesTests/NeetCode/PrefixSum/SubarraySumEqualsKTest.swift
+++ b/SwiftChallengesTests/NeetCode/PrefixSum/SubarraySumEqualsKTest.swift
@@ -1,0 +1,63 @@
+//
+//  SubarraySumEqualsKTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/5/26.
+//
+
+import XCTest
+
+class SubarraySumEqualsKTest: XCTestCase {
+    let solution = SubarraySumEqualsK()
+
+    // LeetCode example 1: [1,1,1], k=2 → subarrays [1,1] at index 0-1 and 1-2
+    func testExample1() {
+        XCTAssertEqual(solution.subarraySum([1, 1, 1], 2), 2)
+    }
+
+    // LeetCode example 2: [1,2,3], k=3 → [1,2] and [3]
+    func testExample2() {
+        XCTAssertEqual(solution.subarraySum([1, 2, 3], 3), 2)
+    }
+
+    // Single element equals k
+    func testSingleElementMatch() {
+        XCTAssertEqual(solution.subarraySum([5], 5), 1)
+    }
+
+    // Single element does not equal k
+    func testSingleElementNoMatch() {
+        XCTAssertEqual(solution.subarraySum([3], 5), 0)
+    }
+
+    // Entire array sums to k
+    func testWholeArraySumsToK() {
+        XCTAssertEqual(solution.subarraySum([1, 2, 3, 4], 10), 1)
+    }
+
+    // No valid subarray
+    func testNoMatch() {
+        XCTAssertEqual(solution.subarraySum([1, 2, 3], 7), 0)
+    }
+
+    // Negative numbers: [-1, -1, 1], k=0 → [-1,1] at indices 1-2 and 0-2 → wait: [-1,1]=-1+1+...
+    // [-1,-1,1]: prefix sums: 0,-1,-2,-1. k=0: need same prefix sum twice. -1 appears at i=1 and i=3 → 1 subarray [-1,1]... and 0 appears at i=0 and... no. Count=1
+    func testNegativeNumbers() {
+        XCTAssertEqual(solution.subarraySum([-1, -1, 1], 0), 1)
+    }
+
+    // All zeros with k=0: every subarray sums to 0, n=3 → 6 subarrays
+    func testAllZerosKZero() {
+        XCTAssertEqual(solution.subarraySum([0, 0, 0], 0), 6)
+    }
+
+    // Mixed positive and negative, multiple matches
+    func testMixedSignsMultipleMatches() {
+        XCTAssertEqual(solution.subarraySum([3, 4, -7, 3, 1, 3, 1, -4, -2, -2], 0), 6)
+    }
+
+    // k is negative: [1,-1,-1,2], k=-1 → [-1] at index 1, [-1] at index 2, [1,-1,-1] → sum=-1
+    func testNegativeK() {
+        XCTAssertEqual(solution.subarraySum([1, -1, -1, 2], -1), 3)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds O(n) prefix sum + hash map solution for [Subarray Sum Equals K](https://leetcode.com/problems/subarray-sum-equals-k/)
- Adds 10 unit tests covering LeetCode examples, edge cases (negatives, zeros, negative k)

## Test plan
- [ ] Run `SubarraySumEqualsKTest` in Xcode — all tests should pass once solution is implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)