### PR TITLE
Add EvaluateReversePolishNotation solution and unit tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -603,6 +603,9 @@
 		FB2C5DAE2FD40996009550A1 /* MinStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DAD2FD40996009550A1 /* MinStack.swift */; };
 		FB2C5DAF2FD40996009550A1 /* MinStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DAD2FD40996009550A1 /* MinStack.swift */; };
 		FB2C5DB22FD40A24009550A1 /* MinStackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DB12FD40A24009550A1 /* MinStackTest.swift */; };
+		FB2C5DB42FD4C9CE009550A1 /* EvaluateReversePolishNotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DB32FD4C9CE009550A1 /* EvaluateReversePolishNotation.swift */; };
+		FB2C5DB52FD4C9CE009550A1 /* EvaluateReversePolishNotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DB32FD4C9CE009550A1 /* EvaluateReversePolishNotation.swift */; };
+		FB2C5DB82FD4CC7E009550A1 /* EvaluateReversePolishNotationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DB62FD4CC7E009550A1 /* EvaluateReversePolishNotationTest.swift */; };
 		FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */; };
@@ -1073,6 +1076,8 @@
 		FB2C5DAA2FD3FB8E009550A1 /* SubarraySumEqualsKTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubarraySumEqualsKTest.swift; sourceTree = "<group>"; };
 		FB2C5DAD2FD40996009550A1 /* MinStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinStack.swift; sourceTree = "<group>"; };
 		FB2C5DB12FD40A24009550A1 /* MinStackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinStackTest.swift; sourceTree = "<group>"; };
+		FB2C5DB32FD4C9CE009550A1 /* EvaluateReversePolishNotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EvaluateReversePolishNotation.swift; path = SwiftChallenges/NeetCode/Stack/EvaluateReversePolishNotation.swift; sourceTree = SOURCE_ROOT; };
+		FB2C5DB62FD4CC7E009550A1 /* EvaluateReversePolishNotationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluateReversePolishNotationTest.swift; sourceTree = "<group>"; };
 		FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacement.swift; sourceTree = "<group>"; };
 		FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacementTest.swift; sourceTree = "<group>"; };
 		FB49A3812F9D8D140013680A /* TwoSum2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoSum2.swift; sourceTree = "<group>"; };
@@ -2171,6 +2176,7 @@
 			isa = PBXGroup;
 			children = (
 				FB2C5DAD2FD40996009550A1 /* MinStack.swift */,
+				FB2C5DB32FD4C9CE009550A1 /* EvaluateReversePolishNotation.swift */,
 			);
 			path = Stack;
 			sourceTree = "<group>";
@@ -2178,6 +2184,7 @@
 		FB2C5DB02FD409EE009550A1 /* Stack */ = {
 			isa = PBXGroup;
 			children = (
+				FB2C5DB62FD4CC7E009550A1 /* EvaluateReversePolishNotationTest.swift */,
 				FB2C5DB12FD40A24009550A1 /* MinStackTest.swift */,
 			);
 			path = Stack;
@@ -2470,6 +2477,7 @@
 				DECA9DF628C95E7500E88CCD /* ChessBoardCellColor.swift in Sources */,
 				DECCEE1527FCF839007BA99C /* NumberToBinary.swift in Sources */,
 				DEDB4954283DF75000B2238B /* UtopianTree.swift in Sources */,
+				FB2C5DB52FD4C9CE009550A1 /* EvaluateReversePolishNotation.swift in Sources */,
 				DECCEE8E27FCF8B4007BA99C /* AirportRoute.swift in Sources */,
 				DECCEE7A27FCF8B4007BA99C /* BusyStudent.swift in Sources */,
 				DECCEE7D27FCF8B4007BA99C /* DailyTemperatures.swift in Sources */,
@@ -2710,6 +2718,7 @@
 				DE604CA92808D9AB00C62CE6 /* NumberOfWays.swift in Sources */,
 				DECCF08527FD8825007BA99C /* SmallerThanCurrentTest.swift in Sources */,
 				DECCEF9527FCF9C1007BA99C /* LongestCommonPrefixTest.swift in Sources */,
+				FB2C5DB42FD4C9CE009550A1 /* EvaluateReversePolishNotation.swift in Sources */,
 				FB49A3AE2F9F1B710013680A /* GroupAnagramsTest.swift in Sources */,
 				DECCEFE027FCFB99007BA99C /* Sorter.swift in Sources */,
 				DE4B8F58289A6A2300DF9D4C /* AllLongestStrings.swift in Sources */,
@@ -3119,6 +3128,7 @@
 				DECCEEC927FCF942007BA99C /* MedianOfTwoSortedArrays.swift in Sources */,
 				DE7979DD28D29B7E00696ACD /* CombinationSumTest.swift in Sources */,
 				DE4B8F69289B2D8B00DF9D4C /* ReverseParenthesesTest.swift in Sources */,
+				FB2C5DB82FD4CC7E009550A1 /* EvaluateReversePolishNotationTest.swift in Sources */,
 				DECCF03727FCFC36007BA99C /* HeapSortTest.swift in Sources */,
 				DECCEED527FCF94A007BA99C /* BasicCombineExample.swift in Sources */,
 			);

--- a/SwiftChallenges/NeetCode/Stack/EvaluateReversePolishNotation.swift
+++ b/SwiftChallenges/NeetCode/Stack/EvaluateReversePolishNotation.swift
@@ -1,0 +1,45 @@
+//
+//  EvaluateReversePolishNotation.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//  https://leetcode.com/problems/evaluate-reverse-polish-notation/
+
+class EvaluateReversePolishNotation {
+    enum operation: String {
+        case plus = "+"
+        case minus = "-"
+        case multiply = "*"
+        case divide = "/"
+    }
+    
+    var stack = [Int]()
+
+    func evalRPN(_ tokens: [String]) -> Int {
+        let operations: [operation] = [.plus, .minus, .multiply, .divide]
+        
+        for token in tokens {
+            if operations.contains(where: { $0.rawValue == token }) {
+                let b = stack.removeLast()
+                let a = stack.removeLast()
+                
+                switch token {
+                case operation.plus.rawValue:
+                    stack.append(a + b)
+                case operation.minus.rawValue:
+                    stack.append(a - b)
+                case operation.multiply.rawValue:
+                    stack.append(a * b)
+                case operation.divide.rawValue:
+                    stack.append(a / b)
+                default:
+                    break
+                }
+            } else {
+                stack.append(Int(token)!)
+            }
+        }
+        let result = stack.removeLast()
+        return result
+    }
+}

--- a/SwiftChallengesTests/NeetCode/Stack/EvaluateReversePolishNotationTest.swift
+++ b/SwiftChallengesTests/NeetCode/Stack/EvaluateReversePolishNotationTest.swift
@@ -1,0 +1,53 @@
+//
+//  EvaluateReversePolishNotationTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//
+
+import XCTest
+
+class EvaluateReversePolishNotationTest: XCTestCase {
+
+    // LeetCode example 1: ["2","1","+","3","*"] -> 9
+    func testLeetCodeExample1() {
+        let sut = EvaluateReversePolishNotation()
+        XCTAssertEqual(sut.evalRPN(["2", "1", "+", "3", "*"]), 9)
+    }
+
+    // LeetCode example 2: ["4","13","5","/","+"] -> 6
+    func testLeetCodeExample2() {
+        let sut = EvaluateReversePolishNotation()
+        XCTAssertEqual(sut.evalRPN(["4", "13", "5", "/", "+"]), 6)
+    }
+
+    // LeetCode example 3: nested expression with negatives -> 22
+    func testLeetCodeExample3() {
+        let sut = EvaluateReversePolishNotation()
+        XCTAssertEqual(sut.evalRPN(["10", "6", "9", "3", "+", "-11", "*", "/", "*", "17", "+", "5", "+"]), 22)
+    }
+
+    // Single token: just a number
+    func testSingleNumber() {
+        let sut = EvaluateReversePolishNotation()
+        XCTAssertEqual(sut.evalRPN(["42"]), 42)
+    }
+
+    // Division truncates toward zero (not floor): -7/2 = -3, not -4
+    func testDivisionTruncatesTowardZero() {
+        let sut = EvaluateReversePolishNotation()
+        XCTAssertEqual(sut.evalRPN(["-7", "2", "/"]), -3)
+    }
+
+    // Subtraction produces a negative result
+    func testSubtractionNegativeResult() {
+        let sut = EvaluateReversePolishNotation()
+        XCTAssertEqual(sut.evalRPN(["3", "11", "-"]), -8)
+    }
+
+    // Negative operands with multiplication
+    func testNegativeOperandsMultiply() {
+        let sut = EvaluateReversePolishNotation()
+        XCTAssertEqual(sut.evalRPN(["-3", "-4", "*"]), 12)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds stack-based solution for [Evaluate Reverse Polish Notation](https://leetcode.com/problems/evaluate-reverse-polish-notation/)
- Adds 7 unit tests covering all 3 LeetCode examples, single token, truncation-toward-zero division, negative results, and negative operands

## Test plan
- [x] All 3 LeetCode examples pass
- [ ] Single number token returns correct value
- [ ] Division truncates toward zero (`-7/2 = -3`)
- [ ] Subtraction with negative result
- [ ] Multiplication with negative operands

🤖 Generated with [Claude Code](https://claude.com/claude-code)