### PR TITLE
Add NextGreaterElementI solution and unit tests (#113)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -609,6 +609,9 @@
 		FB2C5DBA2FD4CE49009550A1 /* LargestRectangleHistogram.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DB92FD4CE49009550A1 /* LargestRectangleHistogram.swift */; };
 		FB2C5DBB2FD4CE49009550A1 /* LargestRectangleHistogram.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DB92FD4CE49009550A1 /* LargestRectangleHistogram.swift */; };
 		FB2C5DBD2FD4D141009550A1 /* LargestRectangleHistogramTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DBC2FD4D141009550A1 /* LargestRectangleHistogramTest.swift */; };
+		FB2C5DC02FD527D2009550A1 /* NextGreaterElementI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */; };
+		FB2C5DC12FD527D2009550A1 /* NextGreaterElementI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */; };
+		FB2C5DC42FD5281B009550A1 /* NextGreaterElementITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DC32FD5281B009550A1 /* NextGreaterElementITest.swift */; };
 		FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */; };
@@ -1083,6 +1086,8 @@
 		FB2C5DB62FD4CC7E009550A1 /* EvaluateReversePolishNotationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluateReversePolishNotationTest.swift; sourceTree = "<group>"; };
 		FB2C5DB92FD4CE49009550A1 /* LargestRectangleHistogram.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargestRectangleHistogram.swift; sourceTree = "<group>"; };
 		FB2C5DBC2FD4D141009550A1 /* LargestRectangleHistogramTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargestRectangleHistogramTest.swift; sourceTree = "<group>"; };
+		FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextGreaterElementI.swift; sourceTree = "<group>"; };
+		FB2C5DC32FD5281B009550A1 /* NextGreaterElementITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextGreaterElementITest.swift; sourceTree = "<group>"; };
 		FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacement.swift; sourceTree = "<group>"; };
 		FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacementTest.swift; sourceTree = "<group>"; };
 		FB49A3812F9D8D140013680A /* TwoSum2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoSum2.swift; sourceTree = "<group>"; };
@@ -2197,6 +2202,22 @@
 			path = Stack;
 			sourceTree = "<group>";
 		};
+		FB2C5DBE2FD52798009550A1 /* MonotonicStack */ = {
+			isa = PBXGroup;
+			children = (
+				FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */,
+			);
+			path = MonotonicStack;
+			sourceTree = "<group>";
+		};
+		FB2C5DC22FD527F5009550A1 /* MonotonicStack */ = {
+			isa = PBXGroup;
+			children = (
+				FB2C5DC32FD5281B009550A1 /* NextGreaterElementITest.swift */,
+			);
+			path = MonotonicStack;
+			sourceTree = "<group>";
+		};
 		FB49A3842F9D8F120013680A /* TwoPointers */ = {
 			isa = PBXGroup;
 			children = (
@@ -2231,6 +2252,7 @@
 				FB49A3C22FA05F880013680A /* BinarySearch */,
 				FB774C012FA997BD00B1DC28 /* PrefixSum */,
 				FB2C5DB02FD409EE009550A1 /* Stack */,
+				FB2C5DC22FD527F5009550A1 /* MonotonicStack */,
 			);
 			path = NeetCode;
 			sourceTree = "<group>";
@@ -2245,6 +2267,7 @@
 				FB49A3C12FA05F7D0013680A /* BinarySearch */,
 				FB774C052FA9983300B1DC28 /* PrefixSum */,
 				FB2C5DAC2FD40971009550A1 /* Stack */,
+				FB2C5DBE2FD52798009550A1 /* MonotonicStack */,
 			);
 			path = NeetCode;
 			sourceTree = "<group>";
@@ -2559,6 +2582,7 @@
 				DECCEE8D27FCF8B4007BA99C /* DetectCyclicList.swift in Sources */,
 				DECCEE7B27FCF8B4007BA99C /* MoveZeroesInArray.swift in Sources */,
 				FB49A3B42F9F1C9F0013680A /* LinkedListCycle2.swift in Sources */,
+				FB2C5DC12FD527D2009550A1 /* NextGreaterElementI.swift in Sources */,
 				DEA5C1E3282B8676004AE296 /* DivisibleSumPairs.swift in Sources */,
 				DECCEFCB27FCFB4C007BA99C /* PriorityQueue.swift in Sources */,
 				FB49A38E2F9DF3950013680A /* ContainerWithMostWater.swift in Sources */,
@@ -2802,6 +2826,7 @@
 				DECCEF5727FCF9C1007BA99C /* DuplicateZerosTest.swift in Sources */,
 				DECCEF6527FCF9C1007BA99C /* MoneyInLeetcodeBankTest.swift in Sources */,
 				DE2E0F8D280EBE11006D06FA /* WrongAnswerOnlyTest.swift in Sources */,
+				FB2C5DC02FD527D2009550A1 /* NextGreaterElementI.swift in Sources */,
 				DEDB4952283DA30E00B2238B /* HurdleRaceTest.swift in Sources */,
 				FB2C5DBA2FD4CE49009550A1 /* LargestRectangleHistogram.swift in Sources */,
 				FBB267562F95948300CF0DB9 /* MaxProfit.swift in Sources */,
@@ -3084,6 +3109,7 @@
 				DEC3D833287F7C4800EB14F8 /* BeautifulDays.swift in Sources */,
 				DE4B8F50289A62D700DF9D4C /* CanBeIncreasingArray.swift in Sources */,
 				DEE62549283B4186003EC784 /* BetweenTwoSetsTest.swift in Sources */,
+				FB2C5DC42FD5281B009550A1 /* NextGreaterElementITest.swift in Sources */,
 				DEC3D838287F917900EB14F8 /* StickCut.swift in Sources */,
 				DE1CA2F927FED812001D8BD1 /* NumberPlusMinus.swift in Sources */,
 				DECCEED927FCF95A007BA99C /* HttpJsonFormat.swift in Sources */,

--- a/SwiftChallenges/MonotonicStack/NextGreaterElementI.swift
+++ b/SwiftChallenges/MonotonicStack/NextGreaterElementI.swift
@@ -1,0 +1,14 @@
+//
+//  NextGreaterElementI.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//
+
+class NextGreaterElementI {
+    func nextGreaterElement(_ nums1: [Int], _ nums2: [Int]) -> [Int] {
+
+        
+        return []
+    }
+}

--- a/SwiftChallenges/NeetCode/MonotonicStack/NextGreaterElementI.swift
+++ b/SwiftChallenges/NeetCode/MonotonicStack/NextGreaterElementI.swift
@@ -1,0 +1,48 @@
+//
+//  NextGreaterElementI.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//  https://leetcode.com/problems/next-greater-element-i/
+
+class NextGreaterElementI {
+
+    // Strategy: monotonic decreasing stack
+    //
+    // Walk through nums2. Keep a stack of numbers that haven't found
+    // their next greater element yet (always decreasing top→bottom).
+    //
+    // When we see a number larger than the stack's top, that number IS
+    // the next greater element for everything smaller on the stack —
+    // pop and record each one until the stack is no longer smaller.
+    //
+    // After the full pass, anything left in the stack has no next greater.
+    // Then answer each nums1 query with a single map lookup.
+    //
+    // Time: O(n)  Space: O(n)
+
+    func nextGreaterElement(_ nums1: [Int], _ nums2: [Int]) -> [Int] {
+
+        // Maps each number → its next greater element in nums2
+        var nextGreaterMap: [Int: Int] = [:]
+
+        // Monotonic decreasing stack (stores unresolved numbers)
+        var stack: [Int] = []
+
+        for current in nums2 {
+
+            // current is larger than the top → it's the next greater for those elements
+            while let top = stack.last, top < current {
+                stack.removeLast()
+                nextGreaterMap[top] = current
+            }
+
+            // Push current; its next greater hasn't been seen yet
+            stack.append(current)
+        }
+
+        // Anything still in the stack has no next greater element (implicitly -1)
+
+        return nums1.map { nextGreaterMap[$0, default: -1] }
+    }
+}

--- a/SwiftChallenges/NeetCode/Stack/MonotonicStack/NextGreaterElementI.swift
+++ b/SwiftChallenges/NeetCode/Stack/MonotonicStack/NextGreaterElementI.swift
@@ -1,0 +1,14 @@
+//
+//  NextGreaterElementI.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//
+
+class NextGreaterElementI {
+    func nextGreaterElement(_ nums1: [Int], _ nums2: [Int]) -> [Int] {
+
+        
+        return []
+    }
+}

--- a/SwiftChallengesTests/MonotonicStack/NextGreaterElementITest.swift
+++ b/SwiftChallengesTests/MonotonicStack/NextGreaterElementITest.swift
@@ -1,0 +1,12 @@
+//
+//  NextGreaterElementITest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//
+
+import XCTest
+
+class NextGreaterElementITest: XCTestCase {
+    
+}

--- a/SwiftChallengesTests/NeetCode/MonotonicStack/NextGreaterElementITest.swift
+++ b/SwiftChallengesTests/NeetCode/MonotonicStack/NextGreaterElementITest.swift
@@ -1,0 +1,53 @@
+//
+//  NextGreaterElementITest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//
+
+import XCTest
+
+class NextGreaterElementITest: XCTestCase {
+
+    // LeetCode example 1: nums1=[4,1,2], nums2=[1,3,4,2] -> [-1,3,-1]
+    func testLeetCodeExample1() {
+        let sut = NextGreaterElementI()
+        XCTAssertEqual(sut.nextGreaterElement([4, 1, 2], [1, 3, 4, 2]), [-1, 3, -1])
+    }
+
+    // LeetCode example 2: nums1=[2,4], nums2=[1,2,3,4] -> [3,-1]
+    func testLeetCodeExample2() {
+        let sut = NextGreaterElementI()
+        XCTAssertEqual(sut.nextGreaterElement([2, 4], [1, 2, 3, 4]), [3, -1])
+    }
+
+    // Single element with no greater element: nums1=[5], nums2=[5] -> [-1]
+    func testSingleElementNoGreater() {
+        let sut = NextGreaterElementI()
+        XCTAssertEqual(sut.nextGreaterElement([5], [5]), [-1])
+    }
+
+    // Single element with greater element: nums1=[1], nums2=[1,2] -> [2]
+    func testSingleElementWithGreater() {
+        let sut = NextGreaterElementI()
+        XCTAssertEqual(sut.nextGreaterElement([1], [1, 2]), [2])
+    }
+
+    // All elements in nums2 descending — no next greater for any: nums1=[3,2,1], nums2=[3,2,1] -> [-1,-1,-1]
+    func testAllDescendingNoGreater() {
+        let sut = NextGreaterElementI()
+        XCTAssertEqual(sut.nextGreaterElement([3, 2, 1], [3, 2, 1]), [-1, -1, -1])
+    }
+
+    // nums1 is last element of nums2: nums1=[2], nums2=[1,3,2] -> [-1]
+    func testLastElementNoGreater() {
+        let sut = NextGreaterElementI()
+        XCTAssertEqual(sut.nextGreaterElement([2], [1, 3, 2]), [-1])
+    }
+
+    // Next greater is not immediately adjacent: nums1=[1], nums2=[1,0,0,5] -> [5]
+    func testNextGreaterNotAdjacent() {
+        let sut = NextGreaterElementI()
+        XCTAssertEqual(sut.nextGreaterElement([1], [1, 0, 0, 5]), [5])
+    }
+}


### PR DESCRIPTION
## Summary
- Implements Next Greater Element I using a monotonic decreasing stack
- Adds 7 unit tests covering LeetCode examples and edge cases

## Test plan
- [x] LeetCode example 1: `[4,1,2]`, `[1,3,4,2]` → `[-1,3,-1]`
- [x] LeetCode example 2: `[2,4]`, `[1,2,3,4]` → `[3,-1]`
- [x] Single element with no greater, single element with greater
- [x] All descending input, last element, non-adjacent next greater

🤖 Generated with [Claude Code](https://claude.com/claude-code)