### PR TITLE
Add ReverseLinkedList solution and unit tests (#114)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -2266,7 +2266,6 @@
 		FB49A3972F9F0FE70013680A /* NeetCode */ = {
 			isa = PBXGroup;
 			children = (
-				FB2C5DC92FD53304009550A1 /* LinkedList */,
 				FB49A39A2F9F10CB0013680A /* ArraysHashing */,
 				FB49A3852F9D8F470013680A /* TwoPointers */,
 				FBB267572F9594C300CF0DB9 /* SlidingWindow */,
@@ -2275,6 +2274,7 @@
 				FB774C012FA997BD00B1DC28 /* PrefixSum */,
 				FB2C5DB02FD409EE009550A1 /* Stack */,
 				FB2C5DC22FD527F5009550A1 /* MonotonicStack */,
+				FB2C5DC92FD53304009550A1 /* LinkedList */,
 			);
 			path = NeetCode;
 			sourceTree = "<group>";
@@ -2282,7 +2282,6 @@
 		FB49A3982F9F105F0013680A /* NeetCode */ = {
 			isa = PBXGroup;
 			children = (
-				FB2C5DC52FD53248009550A1 /* LinkedList */,
 				FB49A3992F9F10C40013680A /* ArraysHashing */,
 				FB49A3842F9D8F120013680A /* TwoPointers */,
 				FBB267532F95943400CF0DB9 /* SlidingWindow */,
@@ -2291,6 +2290,7 @@
 				FB774C052FA9983300B1DC28 /* PrefixSum */,
 				FB2C5DAC2FD40971009550A1 /* Stack */,
 				FB2C5DBE2FD52798009550A1 /* MonotonicStack */,
+				FB2C5DC52FD53248009550A1 /* LinkedList */,
 			);
 			path = NeetCode;
 			sourceTree = "<group>";

--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -612,6 +612,9 @@
 		FB2C5DC02FD527D2009550A1 /* NextGreaterElementI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */; };
 		FB2C5DC12FD527D2009550A1 /* NextGreaterElementI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */; };
 		FB2C5DC42FD5281B009550A1 /* NextGreaterElementITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DC32FD5281B009550A1 /* NextGreaterElementITest.swift */; };
+		FB2C5DC72FD53283009550A1 /* ReverseLinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DC62FD53283009550A1 /* ReverseLinkedList.swift */; };
+		FB2C5DC82FD53283009550A1 /* ReverseLinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DC62FD53283009550A1 /* ReverseLinkedList.swift */; };
+		FB2C5DCB2FD5335D009550A1 /* ReverseLinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DCA2FD5335D009550A1 /* ReverseLinkedListTest.swift */; };
 		FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */; };
@@ -1088,6 +1091,8 @@
 		FB2C5DBC2FD4D141009550A1 /* LargestRectangleHistogramTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargestRectangleHistogramTest.swift; sourceTree = "<group>"; };
 		FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextGreaterElementI.swift; sourceTree = "<group>"; };
 		FB2C5DC32FD5281B009550A1 /* NextGreaterElementITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextGreaterElementITest.swift; sourceTree = "<group>"; };
+		FB2C5DC62FD53283009550A1 /* ReverseLinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseLinkedList.swift; sourceTree = "<group>"; };
+		FB2C5DCA2FD5335D009550A1 /* ReverseLinkedListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseLinkedListTest.swift; sourceTree = "<group>"; };
 		FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacement.swift; sourceTree = "<group>"; };
 		FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacementTest.swift; sourceTree = "<group>"; };
 		FB49A3812F9D8D140013680A /* TwoSum2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoSum2.swift; sourceTree = "<group>"; };
@@ -2218,6 +2223,22 @@
 			path = MonotonicStack;
 			sourceTree = "<group>";
 		};
+		FB2C5DC52FD53248009550A1 /* LinkedList */ = {
+			isa = PBXGroup;
+			children = (
+				FB2C5DC62FD53283009550A1 /* ReverseLinkedList.swift */,
+			);
+			path = LinkedList;
+			sourceTree = "<group>";
+		};
+		FB2C5DC92FD53304009550A1 /* LinkedList */ = {
+			isa = PBXGroup;
+			children = (
+				FB2C5DCA2FD5335D009550A1 /* ReverseLinkedListTest.swift */,
+			);
+			path = LinkedList;
+			sourceTree = "<group>";
+		};
 		FB49A3842F9D8F120013680A /* TwoPointers */ = {
 			isa = PBXGroup;
 			children = (
@@ -2245,6 +2266,7 @@
 		FB49A3972F9F0FE70013680A /* NeetCode */ = {
 			isa = PBXGroup;
 			children = (
+				FB2C5DC92FD53304009550A1 /* LinkedList */,
 				FB49A39A2F9F10CB0013680A /* ArraysHashing */,
 				FB49A3852F9D8F470013680A /* TwoPointers */,
 				FBB267572F9594C300CF0DB9 /* SlidingWindow */,
@@ -2260,6 +2282,7 @@
 		FB49A3982F9F105F0013680A /* NeetCode */ = {
 			isa = PBXGroup;
 			children = (
+				FB2C5DC52FD53248009550A1 /* LinkedList */,
 				FB49A3992F9F10C40013680A /* ArraysHashing */,
 				FB49A3842F9D8F120013680A /* TwoPointers */,
 				FBB267532F95943400CF0DB9 /* SlidingWindow */,
@@ -2693,6 +2716,7 @@
 				DECCF05627FCFE49007BA99C /* BSTKthElement.swift in Sources */,
 				DED076F52878E16C005419F1 /* UniquePaths.swift in Sources */,
 				DECCEE9A27FCF8B4007BA99C /* HttpJsonExample.swift in Sources */,
+				FB2C5DC82FD53283009550A1 /* ReverseLinkedList.swift in Sources */,
 				DE71A33128208E930003DD95 /* BSTAverageLevel.swift in Sources */,
 				DECA9DF028C954CF00E88CCD /* EvenDigitsOnly.swift in Sources */,
 				DE71A308281D325F0003DD95 /* NSOrderedSetExample.swift in Sources */,
@@ -2943,6 +2967,7 @@
 				DECCEEC127FCF93D007BA99C /* RunningSumArray.swift in Sources */,
 				DECCEF7227FCF9C1007BA99C /* StringArraysEquivalentTest.swift in Sources */,
 				DEE62554283C5467003EC784 /* PageTurnCount.swift in Sources */,
+				FB2C5DCB2FD5335D009550A1 /* ReverseLinkedListTest.swift in Sources */,
 				DECCEEBF27FCF934007BA99C /* DuplicateZeros.swift in Sources */,
 				DECCF03327FCFC36007BA99C /* QueueTest.swift in Sources */,
 				DECCEEE727FCF97C007BA99C /* SortByMember.swift in Sources */,
@@ -3023,6 +3048,7 @@
 				DE604CB02808E23100C62CE6 /* RevenueMilestonesTest.swift in Sources */,
 				DE604CA62808136D00C62CE6 /* TwoSumTest.swift in Sources */,
 				DEC3D82B287EC26100EB14F8 /* RobotOriginTest.swift in Sources */,
+				FB2C5DC72FD53283009550A1 /* ReverseLinkedList.swift in Sources */,
 				DEC3D826287EB80900EB14F8 /* ReshapeMatrixTest.swift in Sources */,
 				DE71A313281E66FF0003DD95 /* RotaryLockTest.swift in Sources */,
 				DE71A311281E645D0003DD95 /* RotaryLock.swift in Sources */,

--- a/SwiftChallenges/NeetCode/FastSlowPointers/ListNode.swift
+++ b/SwiftChallenges/NeetCode/FastSlowPointers/ListNode.swift
@@ -8,8 +8,7 @@
 public class ListNode {
     public var val: Int
     public var next: ListNode?
-    public init(_ val: Int) {
-        self.val = val
-        self.next = nil
-    }
+    public init() { self.val = 0; self.next = nil; }
+    public init(_ val: Int) { self.val = val; self.next = nil; }
+    public init(_ val: Int, _ next: ListNode?) { self.val = val; self.next = next; }
 }

--- a/SwiftChallenges/NeetCode/LinkedList/ReverseLinkedList.swift
+++ b/SwiftChallenges/NeetCode/LinkedList/ReverseLinkedList.swift
@@ -1,0 +1,20 @@
+//
+//  ReverseLinkedList.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//  https://leetcode.com/problems/reverse-linked-list/
+
+class ReverseLinkedList {
+    func reverseList(_ head: ListNode?) -> ListNode? {
+        var prev: ListNode? = nil
+        var current = head
+        while current != nil {
+            let next = current?.next
+            current?.next = prev
+            prev = current
+            current = next
+        }
+        return prev
+    }
+}

--- a/SwiftChallengesTests/NeetCode/LinkedList/ReverseLinkedListTest.swift
+++ b/SwiftChallengesTests/NeetCode/LinkedList/ReverseLinkedListTest.swift
@@ -1,0 +1,87 @@
+//
+//  ReverseLinkedListTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/6/26.
+//
+
+import XCTest
+
+class ReverseLinkedListTest: XCTestCase {
+    let solution = ReverseLinkedList()
+
+    private func makeList(_ vals: [Int]) -> ListNode? {
+        guard !vals.isEmpty else { return nil }
+        let head = ListNode(vals[0])
+        var current = head
+        for val in vals.dropFirst() {
+            let node = ListNode(val)
+            current.next = node
+            current = node
+        }
+        return head
+    }
+
+    private func toArray(_ head: ListNode?) -> [Int] {
+        var result: [Int] = []
+        var current = head
+        while let node = current {
+            result.append(node.val)
+            current = node.next
+        }
+        return result
+    }
+
+    func testNilHead() {
+        XCTAssertNil(solution.reverseList(nil))
+    }
+
+    func testSingleNode() {
+        let head = makeList([1])
+        let result = solution.reverseList(head)
+        XCTAssertEqual(toArray(result), [1])
+    }
+
+    func testTwoNodes() {
+        let head = makeList([1, 2])
+        let result = solution.reverseList(head)
+        XCTAssertEqual(toArray(result), [2, 1])
+    }
+
+    func testExample1() {
+        // LeetCode example: [1,2,3,4,5] -> [5,4,3,2,1]
+        let head = makeList([1, 2, 3, 4, 5])
+        let result = solution.reverseList(head)
+        XCTAssertEqual(toArray(result), [5, 4, 3, 2, 1])
+    }
+
+    func testExample2() {
+        // LeetCode example: [1,2] -> [2,1]
+        let head = makeList([1, 2])
+        let result = solution.reverseList(head)
+        XCTAssertEqual(toArray(result), [2, 1])
+    }
+
+    func testOriginalListIsFullyReversed() {
+        let head = makeList([3, 6, 9])
+        let result = solution.reverseList(head)
+        XCTAssertEqual(toArray(result), [9, 6, 3])
+    }
+
+    func testNewHeadIsOldTail() {
+        let head = makeList([1, 2, 3, 4, 5])
+        let result = solution.reverseList(head)
+        XCTAssertEqual(result?.val, 5)
+    }
+
+    func testNewTailNextIsNil() {
+        let head = makeList([1, 2, 3])
+        let result = solution.reverseList(head)
+        var current = result
+        while current?.next != nil {
+            current = current?.next
+        }
+        XCTAssertNil(current?.next)
+        XCTAssertEqual(current?.val, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds iterative `reverseList` solution using three-pointer approach (`prev`, `current`, `next`)
- Adds `ReverseLinkedListTest` with 8 unit tests covering nil input, single node, two nodes, LeetCode examples, and structural invariants
- Extends `ListNode` with `init()` and `init(_ val: Int, _ next: ListNode?)` convenience initializers

## Test plan
- [ ] All `ReverseLinkedListTest` cases pass
- [ ] No regressions in existing `FastSlowPointers` tests that use `ListNode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)