### PR TITLE
Add MergeKSortedLists solution and unit tests (#117)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -621,6 +621,9 @@
 		FB2C5DD22FD549F4009550A1 /* RemoveNthNodeFromEndOfList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DD12FD549F4009550A1 /* RemoveNthNodeFromEndOfList.swift */; };
 		FB2C5DD32FD549F4009550A1 /* RemoveNthNodeFromEndOfList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DD12FD549F4009550A1 /* RemoveNthNodeFromEndOfList.swift */; };
 		FB2C5DD52FD54ECB009550A1 /* RemoveNthNodeFromEndOfListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DD42FD54ECB009550A1 /* RemoveNthNodeFromEndOfListTest.swift */; };
+		FB2C5DD72FD54FE7009550A1 /* MergeKSortedLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DD62FD54FE7009550A1 /* MergeKSortedLists.swift */; };
+		FB2C5DD82FD54FE7009550A1 /* MergeKSortedLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DD62FD54FE7009550A1 /* MergeKSortedLists.swift */; };
+		FB2C5DDD2FD5506C009550A1 /* MergeKSortedListsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DDC2FD5506C009550A1 /* MergeKSortedListsTest.swift */; };
 		FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */; };
@@ -1103,6 +1106,8 @@
 		FB2C5DCF2FD53B9F009550A1 /* MergeTwoSortedListsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeTwoSortedListsTest.swift; sourceTree = "<group>"; };
 		FB2C5DD12FD549F4009550A1 /* RemoveNthNodeFromEndOfList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveNthNodeFromEndOfList.swift; sourceTree = "<group>"; };
 		FB2C5DD42FD54ECB009550A1 /* RemoveNthNodeFromEndOfListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveNthNodeFromEndOfListTest.swift; sourceTree = "<group>"; };
+		FB2C5DD62FD54FE7009550A1 /* MergeKSortedLists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MergeKSortedLists.swift; path = SwiftChallenges/NeetCode/LinkedList/MergeKSortedLists.swift; sourceTree = SOURCE_ROOT; };
+		FB2C5DDC2FD5506C009550A1 /* MergeKSortedListsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeKSortedListsTest.swift; sourceTree = "<group>"; };
 		FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacement.swift; sourceTree = "<group>"; };
 		FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacementTest.swift; sourceTree = "<group>"; };
 		FB49A3812F9D8D140013680A /* TwoSum2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoSum2.swift; sourceTree = "<group>"; };
@@ -2239,6 +2244,7 @@
 				FB2C5DC62FD53283009550A1 /* ReverseLinkedList.swift */,
 				FB2C5DCC2FD537C2009550A1 /* MergeTwoSortedLists.swift */,
 				FB2C5DD12FD549F4009550A1 /* RemoveNthNodeFromEndOfList.swift */,
+				FB2C5DD62FD54FE7009550A1 /* MergeKSortedLists.swift */,
 			);
 			path = LinkedList;
 			sourceTree = "<group>";
@@ -2246,6 +2252,7 @@
 		FB2C5DC92FD53304009550A1 /* LinkedList */ = {
 			isa = PBXGroup;
 			children = (
+				FB2C5DDC2FD5506C009550A1 /* MergeKSortedListsTest.swift */,
 				FB2C5DCF2FD53B9F009550A1 /* MergeTwoSortedListsTest.swift */,
 				FB2C5DCA2FD5335D009550A1 /* ReverseLinkedListTest.swift */,
 				FB2C5DD42FD54ECB009550A1 /* RemoveNthNodeFromEndOfListTest.swift */,
@@ -2597,6 +2604,7 @@
 				DECCF04C27FCFE49007BA99C /* BSTInversion.swift in Sources */,
 				DECCF06A27FCFEE3007BA99C /* StringArraysEquivalent.swift in Sources */,
 				FB49A3AB2F9F1B640013680A /* GroupAnagrams.swift in Sources */,
+				FB2C5DD82FD54FE7009550A1 /* MergeKSortedLists.swift in Sources */,
 				DEA5C1DB282B7E83004AE296 /* PersonalScoresCount.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
@@ -2911,6 +2919,7 @@
 				DEC3D835287F7C9600EB14F8 /* BeautifulDaysTest.swift in Sources */,
 				DE7979EA28D441CC00696ACD /* DecodeMessage.swift in Sources */,
 				DEB3D0C5286F97CE00F1D24B /* TinyURLTest.swift in Sources */,
+				FB2C5DDD2FD5506C009550A1 /* MergeKSortedListsTest.swift in Sources */,
 				DECCF00327FCFBD3007BA99C /* GraphUtils.swift in Sources */,
 				DEC3D829287EC21A00EB14F8 /* RobotOrigin.swift in Sources */,
 				DECCEEC627FCF942007BA99C /* LargestMissingNumber.swift in Sources */,
@@ -3135,6 +3144,7 @@
 				DECCEF6B27FCF9C1007BA99C /* AllPathsTest.swift in Sources */,
 				FB774C072FA998A100B1DC28 /* RangeSumQuery.swift in Sources */,
 				DECCEF7727FCF9C1007BA99C /* CharacterExpansionTest.swift in Sources */,
+				FB2C5DD72FD54FE7009550A1 /* MergeKSortedLists.swift in Sources */,
 				DECCEF4E27FCF9C1007BA99C /* MoveZeroesInArrayTest.swift in Sources */,
 				DE15997828B4C77A0081E2BE /* TriangularSumTest.swift in Sources */,
 				DE71A318281F484C0003DD95 /* VisibleLeftmostTreeNodes.swift in Sources */,

--- a/SwiftChallenges/NeetCode/LinkedList/MergeKSortedLists.swift
+++ b/SwiftChallenges/NeetCode/LinkedList/MergeKSortedLists.swift
@@ -1,0 +1,49 @@
+//
+//  MergeKSortedLists.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/7/26.
+//  https://leetcode.com/problems/merge-k-sorted-lists/
+
+class MergeKSortedLists {
+    func mergeKLists(_ lists: [ListNode?]) -> ListNode? {
+        guard !lists.isEmpty else { return nil }
+        var remaining = lists
+
+        while remaining.count > 1 {
+            var merged: [ListNode?] = []
+            var i = 0
+            while i < remaining.count {
+                let left = remaining[i]
+                let right = (i + 1 < remaining.count) ? remaining[i + 1] : nil
+                merged.append(mergeTwoLists(left, right))
+                i += 2
+            }
+            remaining = merged
+        }
+
+        return remaining[0]
+    }
+
+    private func mergeTwoLists(_ list1: ListNode?, _ list2: ListNode?) -> ListNode? {
+        let dummy = ListNode(0)
+        var tail: ListNode? = dummy
+        var l1 = list1
+        var l2 = list2
+
+        while l1 != nil && l2 != nil {
+            if l1!.val <= l2!.val {
+                tail?.next = l1
+                l1 = l1?.next
+            } else {
+                tail?.next = l2
+                l2 = l2?.next
+            }
+            tail = tail?.next
+        }
+
+        tail?.next = l1 ?? l2
+
+        return dummy.next
+    }
+}

--- a/SwiftChallengesTests/NeetCode/LinkedList/MergeKSortedListsTest.swift
+++ b/SwiftChallengesTests/NeetCode/LinkedList/MergeKSortedListsTest.swift
@@ -1,0 +1,102 @@
+//
+//  MergeKSortedListsTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/7/26.
+//
+
+import XCTest
+
+class MergeKSortedListsTest: XCTestCase {
+    let solution = MergeKSortedLists()
+
+    private func makeList(_ vals: [Int]) -> ListNode? {
+        guard !vals.isEmpty else { return nil }
+        let head = ListNode(vals[0])
+        var current = head
+        for val in vals.dropFirst() {
+            let node = ListNode(val)
+            current.next = node
+            current = node
+        }
+        return head
+    }
+
+    private func toArray(_ head: ListNode?) -> [Int] {
+        var result: [Int] = []
+        var current = head
+        while let node = current {
+            result.append(node.val)
+            current = node.next
+        }
+        return result
+    }
+
+    // LeetCode example 1: [[1,4,5],[1,3,4],[2,6]] -> [1,1,2,3,4,4,5,6]
+    func testExample1() {
+        let lists: [ListNode?] = [makeList([1, 4, 5]), makeList([1, 3, 4]), makeList([2, 6])]
+        let result = solution.mergeKLists(lists)
+        XCTAssertEqual(toArray(result), [1, 1, 2, 3, 4, 4, 5, 6])
+    }
+
+    // LeetCode example 2: [] -> []
+    func testExample2EmptyInput() {
+        let result = solution.mergeKLists([])
+        XCTAssertNil(result)
+    }
+
+    // LeetCode example 3: [[]] -> []
+    func testExample3SingleEmptyList() {
+        let result = solution.mergeKLists([nil])
+        XCTAssertNil(result)
+    }
+
+    func testSingleList() {
+        let lists: [ListNode?] = [makeList([1, 2, 3])]
+        let result = solution.mergeKLists(lists)
+        XCTAssertEqual(toArray(result), [1, 2, 3])
+    }
+
+    func testAllEmptyLists() {
+        let lists: [ListNode?] = [nil, nil, nil]
+        let result = solution.mergeKLists(lists)
+        XCTAssertNil(result)
+    }
+
+    func testSomeEmptyLists() {
+        let lists: [ListNode?] = [nil, makeList([1, 3]), nil, makeList([2, 4])]
+        let result = solution.mergeKLists(lists)
+        XCTAssertEqual(toArray(result), [1, 2, 3, 4])
+    }
+
+    func testSingleNodeEachList() {
+        let lists: [ListNode?] = [makeList([3]), makeList([1]), makeList([2])]
+        let result = solution.mergeKLists(lists)
+        XCTAssertEqual(toArray(result), [1, 2, 3])
+    }
+
+    func testDuplicateValues() {
+        let lists: [ListNode?] = [makeList([1, 1]), makeList([1, 1]), makeList([1, 1])]
+        let result = solution.mergeKLists(lists)
+        XCTAssertEqual(toArray(result), [1, 1, 1, 1, 1, 1])
+    }
+
+    func testNegativeValues() {
+        let lists: [ListNode?] = [makeList([-3, -1]), makeList([-4, -2]), makeList([-5, 0])]
+        let result = solution.mergeKLists(lists)
+        XCTAssertEqual(toArray(result), [-5, -4, -3, -2, -1, 0])
+    }
+
+    func testUnequalLengthLists() {
+        let lists: [ListNode?] = [makeList([1]), makeList([2, 3, 4, 5]), makeList([6])]
+        let result = solution.mergeKLists(lists)
+        XCTAssertEqual(toArray(result), [1, 2, 3, 4, 5, 6])
+    }
+
+    func testResultIsSorted() {
+        let lists: [ListNode?] = [makeList([5, 10]), makeList([1, 7]), makeList([3, 8])]
+        let result = solution.mergeKLists(lists)
+        let arr = toArray(result)
+        XCTAssertEqual(arr, arr.sorted())
+    }
+}


### PR DESCRIPTION
## Summary
- Divide and conquer solution: repeatedly merge pairs of lists until one remains — O(N log k) time
- Inlined `mergeTwoLists` as a private helper (self-contained, no dependency on `MergeTwoSortedLists`)
- 10 unit tests covering LeetCode examples, empty inputs, duplicates, negatives, and unequal lengths

## Test plan
- [ ] All 10 tests in `MergeKSortedListsTest` pass
- [ ] LeetCode examples 1–3 verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)