### PR TITLE
Add BinaryTreeLevelOrderTraversal solution and unit tests (#121)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -598,6 +598,9 @@
 		DEE62553283C5467003EC784 /* PageTurnCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62552283C5467003EC784 /* PageTurnCount.swift */; };
 		DEE62554283C5467003EC784 /* PageTurnCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62552283C5467003EC784 /* PageTurnCount.swift */; };
 		DEE62556283C5499003EC784 /* PageTurnCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE62555283C5499003EC784 /* PageTurnCountTest.swift */; };
+		FB1543952FDD1C8A00697F86 /* BinaryTreeLevelOrderTraversal.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543942FDD1C8A00697F86 /* BinaryTreeLevelOrderTraversal.swift */; };
+		FB1543962FDD1C8A00697F86 /* BinaryTreeLevelOrderTraversal.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543942FDD1C8A00697F86 /* BinaryTreeLevelOrderTraversal.swift */; };
+		FB1543982FDD1D0800697F86 /* BinaryTreeLevelOrderTraversalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543972FDD1D0800697F86 /* BinaryTreeLevelOrderTraversalTest.swift */; };
 		FB1DFB7E2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB7F2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB812FCFD98D00692126 /* ContinuousSubarraySumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */; };
@@ -1105,6 +1108,8 @@
 		DEE62550283B4DA2003EC784 /* SocksMatchTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocksMatchTest.swift; sourceTree = "<group>"; };
 		DEE62552283C5467003EC784 /* PageTurnCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTurnCount.swift; sourceTree = "<group>"; };
 		DEE62555283C5499003EC784 /* PageTurnCountTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PageTurnCountTest.swift; path = SwiftChallenges/Lab/HackerRank/PageTurnCountTest.swift; sourceTree = SOURCE_ROOT; };
+		FB1543942FDD1C8A00697F86 /* BinaryTreeLevelOrderTraversal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryTreeLevelOrderTraversal.swift; sourceTree = "<group>"; };
+		FB1543972FDD1D0800697F86 /* BinaryTreeLevelOrderTraversalTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryTreeLevelOrderTraversalTest.swift; sourceTree = "<group>"; };
 		FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySum.swift; sourceTree = "<group>"; };
 		FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySumTest.swift; sourceTree = "<group>"; };
 		FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubarraySumEqualsK.swift; sourceTree = "<group>"; };
@@ -2305,6 +2310,7 @@
 			children = (
 				FB2C5DED2FD7BBF9009550A1 /* MaximumDepthBinaryTree.swift */,
 				FB2C5DF32FD7C442009550A1 /* InvertBinaryTree.swift */,
+				FB1543942FDD1C8A00697F86 /* BinaryTreeLevelOrderTraversal.swift */,
 			);
 			path = TreesBfsDfs;
 			sourceTree = "<group>";
@@ -2314,6 +2320,7 @@
 			children = (
 				FB2C5DF62FD7C473009550A1 /* InvertBinaryTreeTest.swift */,
 				FB2C5DF02FD7BE07009550A1 /* MaximumDepthBinaryTreeTest.swift */,
+				FB1543972FDD1D0800697F86 /* BinaryTreeLevelOrderTraversalTest.swift */,
 			);
 			path = TreesBfsDfs;
 			sourceTree = "<group>";
@@ -2658,6 +2665,7 @@
 				FBB267552F95948300CF0DB9 /* MaxProfit.swift in Sources */,
 				DECCF07827FCFEE3007BA99C /* TruncateSentence.swift in Sources */,
 				DE2E0FA0280FF17B006D06FA /* UniformIntegers.swift in Sources */,
+				FB1543962FDD1C8A00697F86 /* BinaryTreeLevelOrderTraversal.swift in Sources */,
 				DEA5C1D6282B3250004AE296 /* StudentGrading.swift in Sources */,
 				DECCF07227FCFEE3007BA99C /* ComputeStringSum.swift in Sources */,
 				DECCEE9C27FCF8B4007BA99C /* EnvironmentFetch.swift in Sources */,
@@ -2922,6 +2930,7 @@
 				DECCEFE227FCFB99007BA99C /* BaseSort.swift in Sources */,
 				DE604CB6280A050700C62CE6 /* MinMaxSum.swift in Sources */,
 				FB2C5DF42FD7C442009550A1 /* InvertBinaryTree.swift in Sources */,
+				FB1543952FDD1C8A00697F86 /* BinaryTreeLevelOrderTraversal.swift in Sources */,
 				DECCF02A27FCFC36007BA99C /* GraphUtilsTest.swift in Sources */,
 				FB49A3B32F9F1C9F0013680A /* LinkedListCycle2.swift in Sources */,
 				DECCF08027FCFF30007BA99C /* LFUCache.swift in Sources */,
@@ -3121,6 +3130,7 @@
 				DECCF03A27FCFC36007BA99C /* LRUCacheTest.swift in Sources */,
 				DECCEEC227FCF942007BA99C /* MoveZeroesInArray.swift in Sources */,
 				DECCF05927FCFE49007BA99C /* MergeTwoBST.swift in Sources */,
+				FB1543982FDD1D0800697F86 /* BinaryTreeLevelOrderTraversalTest.swift in Sources */,
 				DED7961B284F1F1B005EF2E7 /* BinaryTreeSymmetric.swift in Sources */,
 				DECCF03927FCFC36007BA99C /* MergeSortTest.swift in Sources */,
 				DECCEF9C27FCF9C1007BA99C /* ArrayManipulationsTest.swift in Sources */,

--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -637,6 +637,8 @@
 		FB2C5DF42FD7C442009550A1 /* InvertBinaryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DF32FD7C442009550A1 /* InvertBinaryTree.swift */; };
 		FB2C5DF52FD7C442009550A1 /* InvertBinaryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DF32FD7C442009550A1 /* InvertBinaryTree.swift */; };
 		FB2C5DF82FD7C473009550A1 /* InvertBinaryTreeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DF62FD7C473009550A1 /* InvertBinaryTreeTest.swift */; };
+		93B48BDB12AD4876A8414F70 /* TreePrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2000075220BA4121BAC5C8F4 /* TreePrinter.swift */; };
+		C7FBECB1581E4A01B10333B5 /* TreePrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2000075220BA4121BAC5C8F4 /* TreePrinter.swift */; };
 		FB49A37D2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A37E2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */; };
 		FB49A3802F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */; };
@@ -1129,6 +1131,7 @@
 		FB2C5DF02FD7BE07009550A1 /* MaximumDepthBinaryTreeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaximumDepthBinaryTreeTest.swift; sourceTree = "<group>"; };
 		FB2C5DF32FD7C442009550A1 /* InvertBinaryTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InvertBinaryTree.swift; path = SwiftChallenges/NeetCode/TreesBfsDfs/InvertBinaryTree.swift; sourceTree = SOURCE_ROOT; };
 		FB2C5DF62FD7C473009550A1 /* InvertBinaryTreeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvertBinaryTreeTest.swift; sourceTree = "<group>"; };
+		2000075220BA4121BAC5C8F4 /* TreePrinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreePrinter.swift; sourceTree = "<group>"; };
 		FB49A37C2F9D823D0013680A /* LongestRepeatingCharacterReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacement.swift; sourceTree = "<group>"; };
 		FB49A37F2F9D89370013680A /* LongestRepeatingCharacterReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestRepeatingCharacterReplacementTest.swift; sourceTree = "<group>"; };
 		FB49A3812F9D8D140013680A /* TwoSum2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoSum2.swift; sourceTree = "<group>"; };

--- a/SwiftChallenges/NeetCode/TreesBfsDfs/BinaryTreeLevelOrderTraversal.swift
+++ b/SwiftChallenges/NeetCode/TreesBfsDfs/BinaryTreeLevelOrderTraversal.swift
@@ -1,0 +1,30 @@
+//
+//  BinaryTreeLevelOrderTraversal.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/12/26.
+//  https://leetcode.com/problems/binary-tree-level-order-traversal/
+
+class BinaryTreeLevelOrderTraversal {
+    func levelOrder(_ root: TreeNode?) -> [[Int]] {
+        var result = [[Int]]()
+        guard let root else { return result }
+        var queue: [TreeNode] = [root]
+
+        // BFS guarantees all nodes at depth N are enqueued before any at depth N+1.
+        // So queue.count at the top of each outer loop is exactly the width of the
+        // next unprocessed level — draining that many nodes naturally covers one full
+        // level without any explicit boundary marker.
+        while !queue.isEmpty {
+            var level = [Int]()
+            for _ in 0..<queue.count { // count is captured once; children appended inside don't affect it
+                let node = queue.removeFirst()
+                level.append(node.val)
+                if let left = node.left { queue.append(left) }
+                if let right = node.right { queue.append(right) }
+            }
+            result.append(level)
+        }
+        return result
+    }
+}

--- a/SwiftChallengesTests/NeetCode/TreesBfsDfs/BinaryTreeLevelOrderTraversalTest.swift
+++ b/SwiftChallengesTests/NeetCode/TreesBfsDfs/BinaryTreeLevelOrderTraversalTest.swift
@@ -1,0 +1,110 @@
+//
+//  BinaryTreeLevelOrderTraversalTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/12/26.
+//
+
+import XCTest
+
+class BinaryTreeLevelOrderTraversalTest: XCTestCase {
+
+    private let sut = BinaryTreeLevelOrderTraversal()
+
+    // MARK: - Base cases
+
+    func testNilRoot() {
+        XCTAssertEqual(sut.levelOrder(nil), [])
+    }
+
+    func testSingleNode() {
+        XCTAssertEqual(sut.levelOrder(TreeNode(1)), [[1]])
+    }
+
+    // MARK: - LeetCode examples
+
+    // [3,9,20,null,null,15,7] → [[3],[9,20],[15,7]]
+    func testExample1() {
+        let root = TreeNode(3,
+                            TreeNode(9),
+                            TreeNode(20, TreeNode(15), TreeNode(7)))
+        XCTAssertEqual(sut.levelOrder(root), [[3], [9, 20], [15, 7]])
+    }
+
+    // [1] → [[1]]
+    func testExample2() {
+        XCTAssertEqual(sut.levelOrder(TreeNode(1)), [[1]])
+    }
+
+    // [] → []
+    func testExample3() {
+        XCTAssertEqual(sut.levelOrder(nil), [])
+    }
+
+    // MARK: - Skewed trees
+
+    // Left-only chain: each level has one node
+    func testSkewedLeft() {
+        let root = TreeNode(1, TreeNode(2, TreeNode(3), nil), nil)
+        XCTAssertEqual(sut.levelOrder(root), [[1], [2], [3]])
+    }
+
+    // Right-only chain: each level has one node
+    func testSkewedRight() {
+        let root = TreeNode(1, nil, TreeNode(2, nil, TreeNode(3)))
+        XCTAssertEqual(sut.levelOrder(root), [[1], [2], [3]])
+    }
+
+    // MARK: - Level grouping
+
+    // Perfect 3-level tree groups all nodes by depth
+    func testPerfectThreeLevelTree() {
+        //        1
+        //       / \
+        //      2   3
+        //     / \ / \
+        //    4  5 6  7
+        let root = TreeNode(1,
+                            TreeNode(2, TreeNode(4), TreeNode(5)),
+                            TreeNode(3, TreeNode(6), TreeNode(7)))
+        XCTAssertEqual(sut.levelOrder(root), [[1], [2, 3], [4, 5, 6, 7]])
+    }
+
+    // Unbalanced: right subtree has an extra level
+    func testUnbalancedTree() {
+        //      1
+        //     / \
+        //    2   3
+        //         \
+        //          4
+        let root = TreeNode(1,
+                            TreeNode(2),
+                            TreeNode(3, nil, TreeNode(4)))
+        XCTAssertEqual(sut.levelOrder(root), [[1], [2, 3], [4]])
+    }
+
+    // Left subtree one level deeper than right
+    func testLeftHeavyTree() {
+        //      1
+        //     / \
+        //    2   3
+        //   /
+        //  4
+        let root = TreeNode(1,
+                            TreeNode(2, TreeNode(4), nil),
+                            TreeNode(3))
+        XCTAssertEqual(sut.levelOrder(root), [[1], [2, 3], [4]])
+    }
+
+    // MARK: - Values
+
+    func testNegativeValues() {
+        let root = TreeNode(-1, TreeNode(-2), TreeNode(-3))
+        XCTAssertEqual(sut.levelOrder(root), [[-1], [-2, -3]])
+    }
+
+    func testDuplicateValues() {
+        let root = TreeNode(1, TreeNode(1), TreeNode(1))
+        XCTAssertEqual(sut.levelOrder(root), [[1], [1, 1]])
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `BinaryTreeLevelOrderTraversal.levelOrder()` using BFS with level-width snapshotting
- Adds unit tests covering LeetCode examples, skewed trees, unbalanced trees, and edge cases
- Comments explain why `queue.count` naturally captures level width without an explicit boundary marker

## Test plan
- [x] `testNilRoot` — empty input returns `[]`
- [x] `testSingleNode` — root only returns `[[val]]`
- [x] `testExample1/2/3` — LeetCode examples
- [x] `testSkewedLeft/Right` — chains where every level has one node
- [x] `testPerfectThreeLevelTree` — full 3-level tree
- [x] `testUnbalancedTree` / `testLeftHeavyTree` — asymmetric depths
- [ ] `testNegativeValues` / `testDuplicateValues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)