### PR TITLE
Rename Node<T> to LinkedListNode<T>

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -413,10 +413,10 @@
 		DECCEF9E27FCF9C1007BA99C /* ListReverseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEF4C27FCF9C1007BA99C /* ListReverseTest.swift */; };
 		DECCEF9F27FCF9C1007BA99C /* SumOfTwoListsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEF4D27FCF9C1007BA99C /* SumOfTwoListsTest.swift */; };
 		DECCEFB527FCFA73007BA99C /* BasicEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFB227FCFA73007BA99C /* BasicEntry.swift */; };
-		DECCEFB627FCFA73007BA99C /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFB327FCFA73007BA99C /* Node.swift */; };
+		DECCEFB627FCFA73007BA99C /* LinkedListNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFB327FCFA73007BA99C /* LinkedListNode.swift */; };
 		DECCEFB727FCFA73007BA99C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFB427FCFA73007BA99C /* LinkedList.swift */; };
 		DECCEFB827FCFA7F007BA99C /* BasicEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFB227FCFA73007BA99C /* BasicEntry.swift */; };
-		DECCEFB927FCFA7F007BA99C /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFB327FCFA73007BA99C /* Node.swift */; };
+		DECCEFB927FCFA7F007BA99C /* LinkedListNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFB327FCFA73007BA99C /* LinkedListNode.swift */; };
 		DECCEFBA27FCFA7F007BA99C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFB427FCFA73007BA99C /* LinkedList.swift */; };
 		DECCEFC127FCFB28007BA99C /* Pair.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFBC27FCFB28007BA99C /* Pair.swift */; };
 		DECCEFC227FCFB28007BA99C /* LRUCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCEFBD27FCFB28007BA99C /* LRUCache.swift */; };
@@ -1003,7 +1003,7 @@
 		DECCEF4C27FCF9C1007BA99C /* ListReverseTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListReverseTest.swift; sourceTree = "<group>"; };
 		DECCEF4D27FCF9C1007BA99C /* SumOfTwoListsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SumOfTwoListsTest.swift; sourceTree = "<group>"; };
 		DECCEFB227FCFA73007BA99C /* BasicEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicEntry.swift; sourceTree = "<group>"; };
-		DECCEFB327FCFA73007BA99C /* Node.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		DECCEFB327FCFA73007BA99C /* LinkedListNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkedListNode.swift; sourceTree = "<group>"; };
 		DECCEFB427FCFA73007BA99C /* LinkedList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		DECCEFBC27FCFB28007BA99C /* Pair.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pair.swift; sourceTree = "<group>"; };
 		DECCEFBD27FCFB28007BA99C /* LRUCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LRUCache.swift; sourceTree = "<group>"; };
@@ -1934,7 +1934,7 @@
 			children = (
 				DECCEFB227FCFA73007BA99C /* BasicEntry.swift */,
 				DECCEFB427FCFA73007BA99C /* LinkedList.swift */,
-				DECCEFB327FCFA73007BA99C /* Node.swift */,
+				DECCEFB327FCFA73007BA99C /* LinkedListNode.swift */,
 				DE221EE72819473800CAE40D /* SimpleLinkedList.swift */,
 			);
 			path = list;
@@ -2741,7 +2741,7 @@
 				DEC3D837287F917900EB14F8 /* StickCut.swift in Sources */,
 				DE1CA3452802B39D001D8BD1 /* SpiralTraversal.swift in Sources */,
 				DECCEE7F27FCF8B4007BA99C /* EvenNumberDigits.swift in Sources */,
-				DECCEFB627FCFA73007BA99C /* Node.swift in Sources */,
+				DECCEFB627FCFA73007BA99C /* LinkedListNode.swift in Sources */,
 				DECCEE8D27FCF8B4007BA99C /* DetectCyclicList.swift in Sources */,
 				DECCEE7B27FCF8B4007BA99C /* MoveZeroesInArray.swift in Sources */,
 				FB49A3B42F9F1C9F0013680A /* LinkedListCycle2.swift in Sources */,
@@ -2925,7 +2925,7 @@
 				FB49A3AE2F9F1B710013680A /* GroupAnagramsTest.swift in Sources */,
 				DECCEFE027FCFB99007BA99C /* Sorter.swift in Sources */,
 				DE4B8F58289A6A2300DF9D4C /* AllLongestStrings.swift in Sources */,
-				DECCEFB927FCFA7F007BA99C /* Node.swift in Sources */,
+				DECCEFB927FCFA7F007BA99C /* LinkedListNode.swift in Sources */,
 				DE4B8F4B289A257300DF9D4C /* ClimbStairs.swift in Sources */,
 				DEE62547283B4153003EC784 /* BetweenTwoSets.swift in Sources */,
 				DE15997028B4314E0081E2BE /* IPCheckerTest.swift in Sources */,

--- a/SwiftChallenges/DS/cache/LRUCache.swift
+++ b/SwiftChallenges/DS/cache/LRUCache.swift
@@ -13,7 +13,7 @@ class LRUCache<T: Comparable> where T: Hashable {
     var capacity = 0
     var queue: LinkedList<T> = LinkedList<T>()
     var cache: [T: Any] = [:]
-    var nodes: [T: Node<T>] = [:]
+    var nodes: [T: LinkedListNode<T>] = [:]
 
     init(capacity: Int = 0) {
         self.capacity = capacity
@@ -39,7 +39,7 @@ class LRUCache<T: Comparable> where T: Hashable {
 
     private func insert(_ key: T, val: Any) {
         cache[key] = val
-        let first = Node<T>(value: key)
+        let first = LinkedListNode<T>(value: key)
         queue.prepend(node: first)
         nodes[key] = first
     }

--- a/SwiftChallenges/DS/list/LinkedList.swift
+++ b/SwiftChallenges/DS/list/LinkedList.swift
@@ -8,25 +8,25 @@
 import Foundation
 
 public class LinkedList<T: Comparable> {
-    var head: Node<T>? = nil
-    var tail: Node<T>? = nil
+    var head: LinkedListNode<T>? = nil
+    var tail: LinkedListNode<T>? = nil
     var size = 0
 
-    public func getHead() -> Node<T>? {
+    public func getHead() -> LinkedListNode<T>? {
         return self.head
     }
 
-    public func getTail() -> Node<T>? {
+    public func getTail() -> LinkedListNode<T>? {
         return self.tail
     }
     public init(input: Array<T> = []) {
         for i in input {
-            let n = Node<T>(value: i)
+            let n = LinkedListNode<T>(value: i)
             append(node: n)
         }
     }
 
-    public func append(node: Node<T>) {
+    public func append(node: LinkedListNode<T>) {
         if head == nil {
             head = node
             tail = node
@@ -39,11 +39,11 @@ public class LinkedList<T: Comparable> {
     }
 
     public func append(value: T) {
-        let node = Node<T>(value: value)
+        let node = LinkedListNode<T>(value: value)
         append(node: node)
     }
 
-    func prepend(node: Node<T>) {
+    func prepend(node: LinkedListNode<T>) {
         guard self.head != nil else {
             self.head = node
             self.tail = node
@@ -59,11 +59,11 @@ public class LinkedList<T: Comparable> {
     }
 
     func prepend(value: T) {
-        let node = Node<T>(value: value)
+        let node = LinkedListNode<T>(value: value)
         prepend(node: node)
     }
 
-    public func search(searchValue: T) -> Node<T>? {
+    public func search(searchValue: T) -> LinkedListNode<T>? {
         var cur = head
         while cur != nil {
             let n = cur?.getValue()
@@ -76,7 +76,7 @@ public class LinkedList<T: Comparable> {
         return nil
     }
 
-    public func delete(node: Node<T>?) -> Bool {
+    public func delete(node: LinkedListNode<T>?) -> Bool {
         if node != nil {
             let prev = node?.prev
             let next = node?.next
@@ -119,7 +119,7 @@ public class LinkedList<T: Comparable> {
     }
 
     public func printList() {
-        var cur: Node<T>! = head
+        var cur: LinkedListNode<T>! = head
         while(cur != nil) {
             print("\([cur.value])", terminator: " ")
             cur = cur!.next
@@ -128,7 +128,7 @@ public class LinkedList<T: Comparable> {
     }
 
     public func printReverseList() {
-        var cur: Node<T>! = tail
+        var cur: LinkedListNode<T>! = tail
         while(cur != nil) {
             print("\([cur.value])", terminator: " ")
             cur = cur!.prev

--- a/SwiftChallenges/DS/list/LinkedListNode.swift
+++ b/SwiftChallenges/DS/list/LinkedListNode.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class Node<T: Comparable>: Comparable {
+public class LinkedListNode<T: Comparable>: Comparable {
     var value: T
 
     public func getValue() -> T {
@@ -18,18 +18,18 @@ public class Node<T: Comparable>: Comparable {
         self.value = x
     }
     
-    public var prev: Node<T>? = nil
-    public var next: Node<T>? = nil
+    public var prev: LinkedListNode<T>? = nil
+    public var next: LinkedListNode<T>? = nil
 
     init(value: T) {
         self.value = value
     }
 
-    static public func < <E:Comparable> (lhs:Node<E>, rhs:Node<E>) -> Bool {
+    static public func < <E:Comparable> (lhs:LinkedListNode<E>, rhs:LinkedListNode<E>) -> Bool {
         return lhs.value < rhs.value
     }
 
-    static public func == <E:Comparable> (lhs:Node<E>, rhs:Node<E>) -> Bool {
+    static public func == <E:Comparable> (lhs:LinkedListNode<E>, rhs:LinkedListNode<E>) -> Bool {
         return lhs.value == rhs.value
     }
 }

--- a/SwiftChallenges/DS/list/SimpleLinkedList.swift
+++ b/SwiftChallenges/DS/list/SimpleLinkedList.swift
@@ -9,13 +9,13 @@ import Foundation
 
 
 class SimpleLinkedList {
-    var head: Node<Int>? = nil
+    var head: LinkedListNode<Int>? = nil
 
     func append(value: Int) {
         if head == nil {
-            head = Node(value: value)
+            head = LinkedListNode(value: value)
         } else {
-            let node = Node(value: value)
+            let node = LinkedListNode(value: value)
             last?.next = node
         }
     }
@@ -26,7 +26,7 @@ class SimpleLinkedList {
         }
     }
 
-    var last: Node<Int>? {
+    var last: LinkedListNode<Int>? {
         var cur = head
         while cur?.next != nil {
             cur = cur?.next

--- a/SwiftChallenges/Lab/list/DetectCyclicList.swift
+++ b/SwiftChallenges/Lab/list/DetectCyclicList.swift
@@ -7,7 +7,7 @@
 //
 
 class DetectCyclicList {
-    static func hasCycle(node: Node<Int>? ) -> Bool {
+    static func hasCycle(node: LinkedListNode<Int>? ) -> Bool {
         if node == nil || node?.next == nil {
             return false
         }

--- a/SwiftChallenges/Lab/list/ListReverse.swift
+++ b/SwiftChallenges/Lab/list/ListReverse.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 class ListReverse {
-    static func reverse(node: Node<Int>?) -> Node<Int>? {
+    static func reverse(node: LinkedListNode<Int>?) -> LinkedListNode<Int>? {
         var current = node
-        var prev: Node<Int>? = nil
-        var next: Node<Int>? = nil
+        var prev: LinkedListNode<Int>? = nil
+        var next: LinkedListNode<Int>? = nil
 
         while current != nil {
             next = current?.next

--- a/SwiftChallenges/Lab/list/SumOfTwoLists.swift
+++ b/SwiftChallenges/Lab/list/SumOfTwoLists.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 class SumOfTwoLists {
-    static func addTwoNumbers(_ l1: Node<Int>?, _ l2: Node<Int>?) -> Node<Int>? {
+    static func addTwoNumbers(_ l1: LinkedListNode<Int>?, _ l2: LinkedListNode<Int>?) -> LinkedListNode<Int>? {
         var n1 = l1
         var n2 = l2
         var carry = 0

--- a/SwiftChallenges/NeetCode/Graphs/NeetNumberOfIslands.swift
+++ b/SwiftChallenges/NeetCode/Graphs/NeetNumberOfIslands.swift
@@ -3,7 +3,7 @@
 //  SwiftChallenges
 //
 //  Created by KyleLearnedThis on 6/13/26.
-//
+//  https://leetcode.com/problems/number-of-islands/
 
 class NeetNumberOfIslands {
 

--- a/SwiftChallengesTests/Lab/list/SumOfTwoListsTest.swift
+++ b/SwiftChallengesTests/Lab/list/SumOfTwoListsTest.swift
@@ -19,7 +19,7 @@ class SumOfTwoListsTest: XCTestCase {
         printList(actual)
     }
 
-    private func printList(_ head: Node<Int>?) {
+    private func printList(_ head: LinkedListNode<Int>?) {
         var cur = head
         while(cur != nil) {
             let value = String(describing: cur!.getValue())


### PR DESCRIPTION
## Summary
- Renames `Node<T>` to `LinkedListNode<T>` across all usages in `DS/list/`, `DS/cache/`, and `Lab/list/`
- Renames `Node.swift` to `LinkedListNode.swift`
- Frees up the `Node` name for LeetCode graph problems (e.g. Clone Graph)

## Test plan
- [ ] Existing tests for linked list, LRU cache, and lab list problems still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)