### PR TITLE
Add WordLadder solution and unit tests (#128)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -618,6 +618,9 @@
 		FB1543B92FDF4A5200697F86 /* PacificAtlanticWaterFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543B82FDF4A5200697F86 /* PacificAtlanticWaterFlow.swift */; };
 		FB1543BA2FDF4A5200697F86 /* PacificAtlanticWaterFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543B82FDF4A5200697F86 /* PacificAtlanticWaterFlow.swift */; };
 		FB1543BC2FDF4AA400697F86 /* PacificAtlanticWaterFlowTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543BB2FDF4AA400697F86 /* PacificAtlanticWaterFlowTest.swift */; };
+		FB1543BE2FDF540F00697F86 /* NeetWordLadder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543BD2FDF540F00697F86 /* NeetWordLadder.swift */; };
+		FB1543BF2FDF540F00697F86 /* NeetWordLadder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543BD2FDF540F00697F86 /* NeetWordLadder.swift */; };
+		FB1543C12FDF543F00697F86 /* NeetWordLadderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543C02FDF543F00697F86 /* NeetWordLadderTest.swift */; };
 		FB1DFB7E2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB7F2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB812FCFD98D00692126 /* ContinuousSubarraySumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */; };
@@ -1136,6 +1139,8 @@
 		FB1543B52FDE6B3C00697F86 /* GraphNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphNode.swift; sourceTree = "<group>"; };
 		FB1543B82FDF4A5200697F86 /* PacificAtlanticWaterFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacificAtlanticWaterFlow.swift; sourceTree = "<group>"; };
 		FB1543BB2FDF4AA400697F86 /* PacificAtlanticWaterFlowTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacificAtlanticWaterFlowTest.swift; sourceTree = "<group>"; };
+		FB1543BD2FDF540F00697F86 /* NeetWordLadder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetWordLadder.swift; sourceTree = "<group>"; };
+		FB1543C02FDF543F00697F86 /* NeetWordLadderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetWordLadderTest.swift; sourceTree = "<group>"; };
 		FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySum.swift; sourceTree = "<group>"; };
 		FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySumTest.swift; sourceTree = "<group>"; };
 		FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubarraySumEqualsK.swift; sourceTree = "<group>"; };
@@ -2262,6 +2267,7 @@
 				FB1543A52FDE5A0000697F86 /* NeetNumberOfIslands.swift */,
 				FB1543B02FDE6AD000697F86 /* NeetCloneGraph.swift */,
 				FB1543B82FDF4A5200697F86 /* PacificAtlanticWaterFlow.swift */,
+				FB1543BD2FDF540F00697F86 /* NeetWordLadder.swift */,
 			);
 			path = Graphs;
 			sourceTree = "<group>";
@@ -2272,6 +2278,7 @@
 				FB1543A82FDE5A2A00697F86 /* NeetNumberOfIslandsTest.swift */,
 				FB1543B32FDE6AFC00697F86 /* NeetCloneGraphTest.swift */,
 				FB1543BB2FDF4AA400697F86 /* PacificAtlanticWaterFlowTest.swift */,
+				FB1543C02FDF543F00697F86 /* NeetWordLadderTest.swift */,
 			);
 			path = Graphs;
 			sourceTree = "<group>";
@@ -2886,6 +2893,7 @@
 				DECA9DF028C954CF00E88CCD /* EvenDigitsOnly.swift in Sources */,
 				DE71A308281D325F0003DD95 /* NSOrderedSetExample.swift in Sources */,
 				DECCF08727FD8DDD007BA99C /* GoalParser.swift in Sources */,
+				FB1543BE2FDF540F00697F86 /* NeetWordLadder.swift in Sources */,
 				DECCEE7827FCF8B4007BA99C /* DegreeOfArray.swift in Sources */,
 				FB49A3932F9EC4CA0013680A /* TrappingRainWater.swift in Sources */,
 				DEC3D832287F7C4800EB14F8 /* BeautifulDays.swift in Sources */,
@@ -3028,6 +3036,7 @@
 				FB2C5DC02FD527D2009550A1 /* NextGreaterElementI.swift in Sources */,
 				DEDB4952283DA30E00B2238B /* HurdleRaceTest.swift in Sources */,
 				FB2C5DBA2FD4CE49009550A1 /* LargestRectangleHistogram.swift in Sources */,
+				FB1543C12FDF543F00697F86 /* NeetWordLadderTest.swift in Sources */,
 				FBB267562F95948300CF0DB9 /* MaxProfit.swift in Sources */,
 				DECCEFCD27FCFB50007BA99C /* Stack.swift in Sources */,
 				DECCEFE627FCFB99007BA99C /* QuickSort.swift in Sources */,
@@ -3327,6 +3336,7 @@
 				DEE62549283B4186003EC784 /* BetweenTwoSetsTest.swift in Sources */,
 				FB2C5DC42FD5281B009550A1 /* NextGreaterElementITest.swift in Sources */,
 				DEC3D838287F917900EB14F8 /* StickCut.swift in Sources */,
+				FB1543BF2FDF540F00697F86 /* NeetWordLadder.swift in Sources */,
 				DE1CA2F927FED812001D8BD1 /* NumberPlusMinus.swift in Sources */,
 				DECCEED927FCF95A007BA99C /* HttpJsonFormat.swift in Sources */,
 				DECCEEBC27FCF927007BA99C /* FindAllPairsGivenSum.swift in Sources */,

--- a/SwiftChallenges/NeetCode/Graphs/NeetWordLadder.swift
+++ b/SwiftChallenges/NeetCode/Graphs/NeetWordLadder.swift
@@ -1,0 +1,158 @@
+//
+//  NeetWordLadder.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/14/26.
+//  https://leetcode.com/problems/word-ladder/
+
+// MARK: - Problem
+// Given a beginWord, endWord, and wordList, return the number of words in the
+// shortest transformation sequence from beginWord → endWord where:
+//   • Each step changes exactly one letter
+//   • Every intermediate word must exist in wordList
+// Return 0 if no such sequence exists.
+//
+// Example: "hit" → "hot" → "dot" → "dog" → "cog"  →  returns 5
+
+class NeetWordLadder {
+
+    // MARK: - V1: BFS — generate neighbours on-the-fly (try every a–z swap)
+    //
+    // BFS naturally finds the shortest path in an unweighted graph.
+    // Each "word" is a node; two words are connected by an edge if they differ
+    // by exactly one letter AND both exist in the word set.
+    //
+    // Key insight: instead of building the full graph up-front (expensive),
+    // generate neighbours on-the-fly by trying every letter a–z at every position.
+    // This is O(word_length × 26) per word instead of O(|wordList|²) comparisons.
+    //
+    // Time:  O(N × M × 26)  where N = wordList.size, M = word length
+    // Space: O(N)            for the word set and BFS queue
+
+    func ladderLength(_ beginWord: String, _ endWord: String, _ wordList: [String]) -> Int {
+        // Use a Set for O(1) membership tests and fast removal.
+        // Removing a word once it's been enqueued prevents revisiting
+        // the same word via a longer path (acts as the "visited" set).
+        var wordSet = Set(wordList)
+
+        // Early exit: if endWord isn't reachable at all, skip the search.
+        guard wordSet.contains(endWord) else { return 0 }
+
+        // BFS queue — each element is a word at the current depth level.
+        // steps starts at 1 because beginWord itself counts as one word
+        // in the sequence (LeetCode counts nodes, not edges).
+        var queue = [beginWord]
+        var steps = 1
+
+        while !queue.isEmpty {
+            // We're entering a new level, so the sequence length grows by 1.
+            steps += 1
+            var nextLevel: [String] = []
+
+            // Process every word at the current BFS level before going deeper.
+            for word in queue {
+                var chars = Array(word) // work on a mutable character array
+
+                for i in chars.indices {
+                    let original = chars[i]
+
+                    // Try replacing position i with every letter a–z.
+                    for letter in "abcdefghijklmnopqrstuvwxyz" {
+                        guard letter != original else { continue } // skip no-op
+
+                        chars[i] = letter
+                        let candidate = String(chars)
+
+                        // Found the endWord — return immediately (shortest path).
+                        if candidate == endWord { return steps }
+
+                        // If candidate is in the word set, it's a valid next hop.
+                        // Remove it so later BFS levels can't use a longer path to it.
+                        if wordSet.contains(candidate) {
+                            wordSet.remove(candidate)
+                            nextLevel.append(candidate)
+                        }
+                    }
+
+                    chars[i] = original // restore before moving to next position
+                }
+            }
+
+            queue = nextLevel // advance to the next BFS level
+        }
+
+        // Exhausted all reachable words without finding endWord.
+        return 0
+    }
+
+    // MARK: - V2: BFS — pre-built pattern adjacency map (NeetCode video approach)
+    //
+    // Instead of trying all 26 letters at runtime, we preprocess the word list
+    // into a pattern → [words] map. A pattern is a word with one position
+    // replaced by "*". Two words that share a pattern differ by exactly one letter.
+    //
+    // Example:  "hot" produces patterns ["*ot", "h*t", "ho*"]
+    //           "dot" produces patterns ["*ot", "d*t", "do*"]
+    //           Both share "*ot", so they are neighbours.
+    //
+    // This trades preprocessing work for cheaper neighbour lookup during BFS —
+    // especially useful when the alphabet is large or words are long.
+    //
+    // Preprocessing: O(N × M)  — N words, each has M patterns of length M
+    // BFS:           O(N × M)  — each word/pattern pair visited at most once
+    // Space:         O(N × M)  — for the pattern map
+
+    func ladderLengthWildcardAdjacency(_ beginWord: String, _ endWord: String, _ wordList: [String]) -> Int {
+        guard wordList.contains(endWord) else { return 0 }
+
+        // Build pattern → [word] adjacency map.
+        // All words that share a pattern are one-letter-change neighbours.
+        var patternMap: [String: [String]] = [:]
+        let allWords = [beginWord] + wordList // beginWord may not be in wordList
+
+        for word in allWords {
+            var chars = Array(word)
+            for i in chars.indices {
+                let original = chars[i]
+                chars[i] = "*"
+                let pattern = String(chars)
+                patternMap[pattern] = (patternMap[pattern] ?? []) + [word]
+                chars[i] = original // restore for the next position
+            }
+        }
+
+        // Standard BFS — visited set prevents re-enqueuing a word via a longer path.
+        var visited = Set<String>([beginWord])
+        var queue = [beginWord]
+        var steps = 1
+
+        while !queue.isEmpty {
+            steps += 1
+            var nextLevel: [String] = []
+
+            for word in queue {
+                var chars = Array(word)
+                for i in chars.indices {
+                    let original = chars[i]
+                    chars[i] = "*"
+                    let pattern = String(chars)
+                    chars[i] = original
+
+                    // All neighbours of `word` share this pattern.
+                    for neighbour in patternMap[pattern] ?? [] {
+                        if neighbour == endWord {
+                            return steps
+                        }
+                        guard !visited.contains(neighbour) else { continue }
+                        visited.insert(neighbour)
+                        nextLevel.append(neighbour)
+                    }
+                }
+            }
+
+            queue = nextLevel
+        }
+
+        return 0
+    }
+}

--- a/SwiftChallengesTests/NeetCode/Graphs/NeetWordLadderTest.swift
+++ b/SwiftChallengesTests/NeetCode/Graphs/NeetWordLadderTest.swift
@@ -1,0 +1,186 @@
+//
+//  NeetWordLadderTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/14/26.
+//
+
+import XCTest
+
+class NeetWordLadderTest: XCTestCase {
+
+    private let sut = NeetWordLadder()
+
+    // MARK: - LeetCode examples
+
+    // hit → hot → dot → dog → cog (5 words)
+    func testExample1() {
+        XCTAssertEqual(
+            sut.ladderLength("hit", "cog", ["hot", "dot", "dog", "lot", "log", "cog"]),
+            5
+        )
+    }
+
+    // endWord "cog" not in wordList → no path
+    func testExample2() {
+        XCTAssertEqual(
+            sut.ladderLength("hit", "cog", ["hot", "dot", "dog", "lot", "log"]),
+            0
+        )
+    }
+
+    // MARK: - Base cases
+
+    func testEmptyWordList() {
+        XCTAssertEqual(sut.ladderLength("hit", "cog", []), 0)
+    }
+
+    func testEndWordNotInList() {
+        XCTAssertEqual(sut.ladderLength("abc", "xyz", ["ayz", "axz", "abz"]), 0)
+    }
+
+    // One character change, endWord directly reachable
+    func testDirectTransformation() {
+        XCTAssertEqual(sut.ladderLength("hot", "dot", ["dot"]), 2)
+    }
+
+    // beginWord already one step from endWord via a different word in list
+    func testTwoStepPath() {
+        XCTAssertEqual(sut.ladderLength("hot", "log", ["lot", "log"]), 3)
+    }
+
+    // MARK: - No valid path
+
+    // No word in list bridges the gap
+    func testNoPath() {
+        XCTAssertEqual(sut.ladderLength("hit", "cog", ["hot", "cog"]), 0)
+    }
+
+    // wordList contains endWord but no bridge words
+    func testIsolatedEndWord() {
+        XCTAssertEqual(sut.ladderLength("abc", "xyz", ["xyz"]), 0)
+    }
+
+    // MARK: - Shortest path selection
+
+    // Two routes exist; function must return the shorter one
+    // Short: a→b→c (3), Long: a→d→e→c (4)
+    func testShortestOfTwoPaths() {
+        // "aaa" → "baa" → "bba" OR "aaa" → "aba" → "bba"
+        // all reachable in 3; confirm we don't return 4
+        XCTAssertEqual(
+            sut.ladderLength("aaa", "bba", ["baa", "bba", "aba"]),
+            3
+        )
+    }
+
+    // MARK: - Single-character words
+
+    func testSingleCharDirectMatch() {
+        XCTAssertEqual(sut.ladderLength("a", "b", ["b"]), 2)
+    }
+
+    func testSingleCharNoPath() {
+        XCTAssertEqual(sut.ladderLength("a", "c", ["b"]), 0)
+    }
+
+    // MARK: - Dead-end branches
+
+    // wordList has a dead-end branch that doesn't lead to endWord
+    func testDeadEndBranchIgnored() {
+        // "hit" → "hot" → "dot" → "dog" → "cog"
+        // "dot" → "lot" → "log" is a dead end (no "cog" reachable from "log" without "cog" in list)
+        XCTAssertEqual(
+            sut.ladderLength("hit", "cog", ["hot", "dot", "dog", "cog", "lot", "log"]),
+            5
+        )
+    }
+
+    // MARK: - Longer chain
+
+    func testLongerChain() {
+        // a → b → c → d → e, each differing by one letter
+        // "aaaa" → "baaa" → "bbaa" → "bbba" → "bbbb"
+        let wordList = ["baaa", "bbaa", "bbba", "bbbb"]
+        XCTAssertEqual(sut.ladderLength("aaaa", "bbbb", wordList), 5)
+    }
+
+    // MARK: - V2 (pattern map) LeetCode examples
+
+    func testV2Example1() {
+        XCTAssertEqual(
+            sut.ladderLengthWildcardAdjacency("hit", "cog", ["hot", "dot", "dog", "lot", "log", "cog"]),
+            5
+        )
+    }
+
+    func testV2Example2() {
+        XCTAssertEqual(
+            sut.ladderLengthWildcardAdjacency("hit", "cog", ["hot", "dot", "dog", "lot", "log"]),
+            0
+        )
+    }
+
+    // MARK: - V2 Base cases
+
+    func testV2EmptyWordList() {
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("hit", "cog", []), 0)
+    }
+
+    func testV2EndWordNotInList() {
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("abc", "xyz", ["ayz", "axz", "abz"]), 0)
+    }
+
+    func testV2DirectTransformation() {
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("hot", "dot", ["dot"]), 2)
+    }
+
+    func testV2TwoStepPath() {
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("hot", "log", ["lot", "log"]), 3)
+    }
+
+    // MARK: - V2 No valid path
+
+    func testV2NoPath() {
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("hit", "cog", ["hot", "cog"]), 0)
+    }
+
+    func testV2IsolatedEndWord() {
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("abc", "xyz", ["xyz"]), 0)
+    }
+
+    // MARK: - V2 Shortest path selection
+
+    func testV2ShortestOfTwoPaths() {
+        XCTAssertEqual(
+            sut.ladderLengthWildcardAdjacency("aaa", "bba", ["baa", "bba", "aba"]),
+            3
+        )
+    }
+
+    // MARK: - V2 Single-character words
+
+    func testV2SingleCharDirectMatch() {
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("a", "b", ["b"]), 2)
+    }
+
+    func testV2SingleCharNoPath() {
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("a", "c", ["b"]), 0)
+    }
+
+    // MARK: - V2 Dead-end branches
+
+    func testV2DeadEndBranchIgnored() {
+        XCTAssertEqual(
+            sut.ladderLengthWildcardAdjacency("hit", "cog", ["hot", "dot", "dog", "cog", "lot", "log"]),
+            5
+        )
+    }
+
+    // MARK: - V2 Longer chain
+
+    func testV2LongerChain() {
+        let wordList = ["baaa", "bbaa", "bbba", "bbbb"]
+        XCTAssertEqual(sut.ladderLengthWildcardAdjacency("aaaa", "bbbb", wordList), 5)
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `ladderLength` via BFS with on-the-fly a–z character swaps (V1)
- Implements `ladderLengthWildcardAdjacency` via pre-built wildcard pattern adjacency map (V2), following the NeetCode video approach where each word generates patterns like `hot → *ot, h*t, ho*`
- 26 unit tests covering LeetCode examples, base cases, no-path scenarios, shortest-path selection, single-char words, dead-end branches, and longer chains

## Test plan
- [x] All 26 `NeetWordLadderTest` cases pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)