### PR TITLE
Add Permutations solution and unit tests (#131)

### DIFF
--- a/.claude/commands/leetcode.md
+++ b/.claude/commands/leetcode.md
@@ -1,6 +1,6 @@
 ---
 description: Scaffold a new NeetCode problem — generates a solution stub, an empty XCTest file, and registers both into project.pbxproj.
-argument-hint: class=<ClassName> group=<Category>
+argument-hint: problem=<"46. Permutations"> OR class=<ClassName> group=<Category>
 ---
 
 # /leetcode — Scaffold a NeetCode Problem
@@ -9,14 +9,27 @@ Scaffold a new LeetCode/NeetCode problem in this SwiftChallenges Xcode project. 
 
 ## Arguments
 
-`$ARGUMENTS` is a space-separated list of two required key=value pairs (order-insensitive):
+`$ARGUMENTS` accepts **one of two forms**:
 
-- `class=<ClassName>` — solution class & filename (no `.swift` suffix). PascalCase, by convention prefixed with `Neet` for newer problems (e.g. `NeetPermutations`).
-- `group=<Category>` — NeetCode category folder name (e.g. `Backtracking`, `Trees`, `SlidingWindow`).
+### Form A — Auto-resolve from problem identity (preferred)
+- `problem=<identifier>` — accepts a problem number, name, URL slug, or combined (e.g. `problem="46. Permutations"`, `problem="permutations"`, `problem=46`).
+
+When `problem=` is provided, use your training knowledge to resolve:
+- `class` — PascalCase class name prefixed with `Neet` (e.g. `NeetPermutations`)
+- `group` — NeetCode category folder (e.g. `Backtracking`, `Trees`, `SlidingWindow`)
+- `signature` — the exact LeetCode Swift function signature (e.g. `func permute(_ nums: [Int]) -> [[Int]]`)
+
+Use `signature` in the solution template (Step 3) instead of `func solve()`.
+
+### Form B — Explicit (fallback)
+- `class=<ClassName>` — solution class & filename (no `.swift` suffix). PascalCase, prefixed with `Neet`.
+- `group=<Category>` — NeetCode category folder name.
+
+When using Form B, use `func solve()` as the placeholder signature.
 
 The test class name is **always** `<class>Test` and is derived automatically — do not accept a separate `test=` argument.
 
-If `$ARGUMENTS` is missing either key, abort with an error message listing which keys are missing and showing the expected invocation format.
+If `$ARGUMENTS` provides neither `problem=` nor both `class=` and `group=`, abort with an error listing what's missing and showing both valid invocation formats.
 
 ## Steps
 
@@ -46,7 +59,16 @@ Use the bash command `date +%-m/%-d/%y` to get the date in the project's header 
 
 Path: `SwiftChallenges/NeetCode/$group/$class.swift`
 
-Use this template with a `func solve()` placeholder and an empty body:
+**Determine the default return value** from the return type in `$signature`:
+- `-> [[T]]` or `-> [T]` → `return []`
+- `-> Int` → `return 0`
+- `-> String` → `return ""`
+- `-> Bool` → `return false`
+- `-> Double` or `-> Float` → `return 0.0`
+- `-> T?` (any optional) → `return nil`
+- `-> Void` or no return type → omit the return line entirely
+
+Use this template. For Form B use `func solve()` and omit the return line:
 
 ```swift
 //
@@ -58,8 +80,8 @@ Use this template with a `func solve()` placeholder and an empty body:
 
 class $class {
 
-    func solve() {
-
+    $signature {
+        return $default
     }
 }
 ```
@@ -68,7 +90,20 @@ class $class {
 
 Path: `SwiftChallengesTests/NeetCode/$group/${class}Test.swift`
 
-Emit an empty test class — Kyle will fill in test methods after reading the problem page:
+**Form A (problem=):** Generate a full test suite using training knowledge of the problem. Follow this structure:
+
+- **Private helpers** — add only what the comparison strategy requires:
+  - Order-agnostic `[[T]]` results (e.g. permutations, subsets, combinations): add a `sorted()` helper that sorts inner arrays then outer array lexicographically, matching the NeetSubsets style.
+  - Scalar or single-array results with a deterministic order: no helper needed; use `XCTAssertEqual` directly.
+- **`verify()` wrapper** — always include one; it routes through the sut call and passes `file:` and `line:` so failures point to the callsite.
+- **Test methods** — organised with `// MARK:` sections:
+  - `// MARK: - Base cases` — empty input, single element, minimal valid input
+  - `// MARK: - LeetCode examples` — every numbered example from the problem statement (testExample1, testExample2, …)
+  - `// MARK: - Edge cases` — negatives, duplicates, boundary values, or property assertions (count, uniqueness) as appropriate to the problem
+
+Use Swift value literals throughout — no variables, no setup beyond the sut.
+
+**Form B (class= / group=):** Emit an empty test class only:
 
 ```swift
 //
@@ -189,8 +224,8 @@ Print a concise summary:
 
 Next:
   1. Open SwiftChallenges.xcodeproj in Xcode (Cmd+B to confirm the build is clean)
-  2. Fill in the real function signature in $class.swift
-  3. Add testExampleN() methods in ${class}Test.swift
+  2. Solve the algorithm in $class.swift
+  3. Run tests — they should fail until the algorithm is correct
 ```
 
 ## Notes

--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -624,6 +624,9 @@
 		FB1543C52FDFB21E00697F86 /* NeetSubsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543C42FDFB21E00697F86 /* NeetSubsets.swift */; };
 		FB1543C62FDFB21E00697F86 /* NeetSubsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543C42FDFB21E00697F86 /* NeetSubsets.swift */; };
 		FB1543C82FDFB27300697F86 /* NeetSubsetsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1543C72FDFB27300697F86 /* NeetSubsetsTest.swift */; };
+		42D58F7AD3D74ED4B6C3A75A /* NeetPermutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8315683B66F55C64F9E2944 /* NeetPermutations.swift */; };
+		AF91A075B7BC0A1FDE3199EE /* NeetPermutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8315683B66F55C64F9E2944 /* NeetPermutations.swift */; };
+		C666BD0812BA8EB22B4D26BE /* NeetPermutationsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */; };
 		FB1DFB7E2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB7F2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB812FCFD98D00692126 /* ContinuousSubarraySumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */; };
@@ -1146,6 +1149,8 @@
 		FB1543C02FDF543F00697F86 /* NeetWordLadderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetWordLadderTest.swift; sourceTree = "<group>"; };
 		FB1543C42FDFB21E00697F86 /* NeetSubsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetSubsets.swift; sourceTree = "<group>"; };
 		FB1543C72FDFB27300697F86 /* NeetSubsetsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetSubsetsTest.swift; sourceTree = "<group>"; };
+		D8315683B66F55C64F9E2944 /* NeetPermutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetPermutations.swift; sourceTree = "<group>"; };
+		4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetPermutationsTest.swift; sourceTree = "<group>"; };
 		FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySum.swift; sourceTree = "<group>"; };
 		FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySumTest.swift; sourceTree = "<group>"; };
 		FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubarraySumEqualsK.swift; sourceTree = "<group>"; };
@@ -2292,6 +2297,7 @@
 			isa = PBXGroup;
 			children = (
 				FB1543C42FDFB21E00697F86 /* NeetSubsets.swift */,
+				D8315683B66F55C64F9E2944 /* NeetPermutations.swift */,
 			);
 			path = Backtracking;
 			sourceTree = "<group>";
@@ -2300,6 +2306,7 @@
 			isa = PBXGroup;
 			children = (
 				FB1543C72FDFB27300697F86 /* NeetSubsetsTest.swift */,
+				4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */,
 			);
 			path = Backtracking;
 			sourceTree = "<group>";
@@ -2771,6 +2778,7 @@
 				FB2C5DE52FD61C5D009550A1 /* ReverseLinkedListII.swift in Sources */,
 				DEA5C1DB282B7E83004AE296 /* PersonalScoresCount.swift in Sources */,
 				FB1543C52FDFB21E00697F86 /* NeetSubsets.swift in Sources */,
+				42D58F7AD3D74ED4B6C3A75A /* NeetPermutations.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3134,6 +3142,7 @@
 				DECCEEB527FCF8EE007BA99C /* ArrayManipulations.swift in Sources */,
 				DECCEF8427FCF9C1007BA99C /* HttpJsonExampleTest.swift in Sources */,
 				FB1543C62FDFB21E00697F86 /* NeetSubsets.swift in Sources */,
+				AF91A075B7BC0A1FDE3199EE /* NeetPermutations.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,
@@ -3389,6 +3398,7 @@
 				DE2E0F90280EBF44006D06FA /* BattleshipProbability.swift in Sources */,
 				DEE62544283AF484003EC784 /* DaysOfRussianProgrammerTest.swift in Sources */,
 				FB1543C82FDFB27300697F86 /* NeetSubsetsTest.swift in Sources */,
+				C666BD0812BA8EB22B4D26BE /* NeetPermutationsTest.swift in Sources */,
 				DECCF08A27FD8ED6007BA99C /* GoalParserTest.swift in Sources */,
 				DED795C4284A06CA005EF2E7 /* TrieTest.swift in Sources */,
 				DECCEF8D27FCF9C1007BA99C /* EvenNumberDigitsTest.swift in Sources */,

--- a/SwiftChallenges/NeetCode/Backtracking/NeetPermutations.swift
+++ b/SwiftChallenges/NeetCode/Backtracking/NeetPermutations.swift
@@ -1,0 +1,36 @@
+//
+//  NeetPermutations.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/15/26.
+//  https://leetcode.com/problems/permutations/
+
+class NeetPermutations {
+
+    func permute(_ nums: [Int]) -> [[Int]] {
+        var result = [[Int]]()
+        var current = [Int]()
+        // tracks which indices are already in the current permutation
+        var used = [Bool](repeating: false, count: nums.count)
+
+        func backtrack() {
+            // current permutation is complete — record it
+            if current.count == nums.count {
+                result.append(current)
+                return
+            }
+            // recursively pick one unused number at a time
+            for i in 0..<nums.count {
+                if used[i] { continue }
+                used[i] = true
+                current.append(nums[i])  // add it to the current path
+                backtrack()              // recurse with the remaining numbers
+                current.removeLast()     // remove it and try the next one — this is the backtrack
+                used[i] = false
+            }
+        }
+
+        backtrack()
+        return result
+    }
+}

--- a/SwiftChallengesTests/NeetCode/Backtracking/NeetPermutationsTest.swift
+++ b/SwiftChallengesTests/NeetCode/Backtracking/NeetPermutationsTest.swift
@@ -1,0 +1,70 @@
+//
+//  NeetPermutationsTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/15/26.
+//
+
+import XCTest
+
+class NeetPermutationsTest: XCTestCase {
+
+    private let sut = NeetPermutations()
+
+    private func sorted(_ perms: [[Int]]) -> [[Int]] {
+        perms.map { $0.sorted() }.sorted { $0.lexicographicallyPrecedes($1) }
+    }
+
+    private func verify(_ nums: [Int], expected: [[Int]], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sorted(sut.permute(nums)), sorted(expected), file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testSingleElement() {
+        verify([1], expected: [[1]])
+    }
+
+    func testTwoElements() {
+        verify([0, 1], expected: [[0, 1], [1, 0]])
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify([1, 2, 3], expected: [
+            [1, 2, 3], [1, 3, 2],
+            [2, 1, 3], [2, 3, 1],
+            [3, 1, 2], [3, 2, 1]
+        ])
+    }
+
+    func testExample2() {
+        verify([0, 1], expected: [[0, 1], [1, 0]])
+    }
+
+    func testExample3() {
+        verify([1], expected: [[1]])
+    }
+
+    // MARK: - Edge cases
+
+    func testPermutationCount() {
+        XCTAssertEqual(sut.permute([1, 2, 3]).count, 6)
+        XCTAssertEqual(sut.permute([1, 2, 3, 4]).count, 24)
+    }
+
+    func testNoPermutationIsDuplicated() {
+        let result = sut.permute([1, 2, 3])
+        let unique = Set(result.map { $0.description })
+        XCTAssertEqual(result.count, unique.count)
+    }
+
+    func testNegativeNumbers() {
+        verify([-1, 0, 1], expected: [
+            [-1, 0, 1], [-1, 1, 0],
+            [0, -1, 1], [0, 1, -1],
+            [1, -1, 0], [1, 0, -1]
+        ])
+    }
+}


### PR DESCRIPTION
## Summary
- Backtracking solution for LeetCode 46 — Permutations using a nested recursive function with a `used[]` boolean array to track which indices are in the current path
- Full test suite covering base cases, all LeetCode examples, edge cases (negative numbers, permutation count, no duplicates)
- Upgraded `/leetcode` skill with `problem=` auto-resolve: derives class name, group, real function signature, default return value, and generates a full test suite from training knowledge

## Test plan
- [x] Cmd+B in Xcode confirms clean build
- [x] Run `NeetPermutationsTest` — all tests pass once algorithm is correct
- [x] `/leetcode problem="..."` correctly scaffolds future problems with real signatures and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)