### PR TITLE
Add CombinationSum solution and unit tests (#132)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -627,6 +627,9 @@
 		42D58F7AD3D74ED4B6C3A75A /* NeetPermutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8315683B66F55C64F9E2944 /* NeetPermutations.swift */; };
 		AF91A075B7BC0A1FDE3199EE /* NeetPermutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8315683B66F55C64F9E2944 /* NeetPermutations.swift */; };
 		C666BD0812BA8EB22B4D26BE /* NeetPermutationsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */; };
+		80AEC4241B9CAAA3CC9D88E5 /* NeetCombinationSum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */; };
+		983B56C59FB0CFEAAB31BC77 /* NeetCombinationSum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */; };
+		300507A1AB042E17EC79420A /* NeetCombinationSumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9720A5ACDA71E699F8A573D /* NeetCombinationSumTest.swift */; };
 		FB1DFB7E2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB7F2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB812FCFD98D00692126 /* ContinuousSubarraySumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */; };
@@ -1151,6 +1154,8 @@
 		FB1543C72FDFB27300697F86 /* NeetSubsetsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetSubsetsTest.swift; sourceTree = "<group>"; };
 		D8315683B66F55C64F9E2944 /* NeetPermutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetPermutations.swift; sourceTree = "<group>"; };
 		4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetPermutationsTest.swift; sourceTree = "<group>"; };
+		A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetCombinationSum.swift; sourceTree = "<group>"; };
+		D9720A5ACDA71E699F8A573D /* NeetCombinationSumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetCombinationSumTest.swift; sourceTree = "<group>"; };
 		FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySum.swift; sourceTree = "<group>"; };
 		FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySumTest.swift; sourceTree = "<group>"; };
 		FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubarraySumEqualsK.swift; sourceTree = "<group>"; };
@@ -2298,6 +2303,7 @@
 			children = (
 				FB1543C42FDFB21E00697F86 /* NeetSubsets.swift */,
 				D8315683B66F55C64F9E2944 /* NeetPermutations.swift */,
+				A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */,
 			);
 			path = Backtracking;
 			sourceTree = "<group>";
@@ -2307,6 +2313,7 @@
 			children = (
 				FB1543C72FDFB27300697F86 /* NeetSubsetsTest.swift */,
 				4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */,
+				D9720A5ACDA71E699F8A573D /* NeetCombinationSumTest.swift */,
 			);
 			path = Backtracking;
 			sourceTree = "<group>";
@@ -2779,6 +2786,7 @@
 				DEA5C1DB282B7E83004AE296 /* PersonalScoresCount.swift in Sources */,
 				FB1543C52FDFB21E00697F86 /* NeetSubsets.swift in Sources */,
 				42D58F7AD3D74ED4B6C3A75A /* NeetPermutations.swift in Sources */,
+				80AEC4241B9CAAA3CC9D88E5 /* NeetCombinationSum.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3143,6 +3151,7 @@
 				DECCEF8427FCF9C1007BA99C /* HttpJsonExampleTest.swift in Sources */,
 				FB1543C62FDFB21E00697F86 /* NeetSubsets.swift in Sources */,
 				AF91A075B7BC0A1FDE3199EE /* NeetPermutations.swift in Sources */,
+				983B56C59FB0CFEAAB31BC77 /* NeetCombinationSum.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,
@@ -3399,6 +3408,7 @@
 				DEE62544283AF484003EC784 /* DaysOfRussianProgrammerTest.swift in Sources */,
 				FB1543C82FDFB27300697F86 /* NeetSubsetsTest.swift in Sources */,
 				C666BD0812BA8EB22B4D26BE /* NeetPermutationsTest.swift in Sources */,
+				300507A1AB042E17EC79420A /* NeetCombinationSumTest.swift in Sources */,
 				DECCF08A27FD8ED6007BA99C /* GoalParserTest.swift in Sources */,
 				DED795C4284A06CA005EF2E7 /* TrieTest.swift in Sources */,
 				DECCEF8D27FCF9C1007BA99C /* EvenNumberDigitsTest.swift in Sources */,

--- a/SwiftChallenges/NeetCode/Backtracking/NeetCombinationSum.swift
+++ b/SwiftChallenges/NeetCode/Backtracking/NeetCombinationSum.swift
@@ -1,0 +1,33 @@
+//
+//  NeetCombinationSum.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/15/26.
+//  https://leetcode.com/problems/combination-sum/
+
+class NeetCombinationSum {
+
+    // O(2^(t/m)) time — t = target, m = min candidate. O(t/m) space for recursion depth.
+    func combinationSum(_ candidates: [Int], _ target: Int) -> [[Int]] {
+        var result = [[Int]]()
+        // At each index: include it (stay at i to allow reuse) or skip to i+1.
+        func dfs(i: Int, current: [Int], total: Int) {
+            var current = current
+            if total == target {
+                result.append(current)
+                return
+            }
+            if i >= candidates.count || total > target {
+                return
+            }
+            // Include: i stays the same so the same candidate can be reused
+            current.append(candidates[i])
+            dfs(i: i, current: current, total: total + candidates[i])
+            // Skip: advance to next candidate
+            current.removeLast()
+            dfs(i: i + 1, current: current, total: total)
+        }
+        dfs(i: 0, current: [], total: 0)
+        return result
+    }
+}

--- a/SwiftChallengesTests/NeetCode/Backtracking/NeetCombinationSumTest.swift
+++ b/SwiftChallengesTests/NeetCode/Backtracking/NeetCombinationSumTest.swift
@@ -1,0 +1,69 @@
+//
+//  NeetCombinationSumTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/15/26.
+//
+
+import XCTest
+
+class NeetCombinationSumTest: XCTestCase {
+
+    private let sut = NeetCombinationSum()
+
+    private func sorted(_ combinations: [[Int]]) -> [[Int]] {
+        combinations.map { $0.sorted() }.sorted { $0.lexicographicallyPrecedes($1) }
+    }
+
+    private func verify(_ candidates: [Int], target: Int, expected: [[Int]], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sorted(sut.combinationSum(candidates, target)), sorted(expected), file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testEmptyCandidates() {
+        verify([], target: 7, expected: [])
+    }
+
+    func testNoSolution() {
+        verify([2], target: 1, expected: [])
+    }
+
+    func testSingleCandidateEqualsTarget() {
+        verify([7], target: 7, expected: [[7]])
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify([2, 3, 6, 7], target: 7, expected: [[2, 2, 3], [7]])
+    }
+
+    func testExample2() {
+        verify([2, 3, 5], target: 8, expected: [[2, 2, 2, 2], [2, 3, 3], [3, 5]])
+    }
+
+    func testExample3() {
+        verify([2], target: 1, expected: [])
+    }
+
+    // MARK: - Edge cases
+
+    func testAllCandidatesExceedTarget() {
+        verify([5, 10, 15], target: 3, expected: [])
+    }
+
+    func testMultipleWaysToReachTarget() {
+        verify([1, 2], target: 4, expected: [[1, 1, 1, 1], [1, 1, 2], [2, 2]])
+    }
+
+    func testNoDuplicateCombinations() {
+        let result = sut.combinationSum([2, 3, 6, 7], 7)
+        let unique = Set(result.map { $0.sorted().description })
+        XCTAssertEqual(result.count, unique.count)
+    }
+
+    func testCandidateReusedMultipleTimes() {
+        verify([3], target: 9, expected: [[3, 3, 3]])
+    }
+}


### PR DESCRIPTION
## Summary
- Implements LeetCode 39. Combination Sum using backtracking DFS
- Adds full XCTest suite with base cases, LeetCode examples, and edge cases
- Registers both files in project.pbxproj

## Test plan
- [x] Cmd+B clean build in Xcode
- [x] All tests pass (empty candidates, no solution, reuse, multiple combinations, no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)