### PR TITLE
Add WordSearch solution and unit tests

### DIFF
--- a/.claude/commands/leetcode.md
+++ b/.claude/commands/leetcode.md
@@ -1,11 +1,11 @@
 ---
-description: Scaffold a new NeetCode problem — generates a solution stub, an empty XCTest file, and registers both into project.pbxproj.
-argument-hint: problem=<"46. Permutations"> OR class=<ClassName> group=<Category>
+description: Scaffold a new LeetCode problem — generates a solution stub, an empty XCTest file, and registers both into project.pbxproj.
+argument-hint: problem=<"46. Permutations"> [prefix=<Prefix>] OR class=<ClassName> group=<Category> [prefix=<Prefix>]
 ---
 
-# /leetcode — Scaffold a NeetCode Problem
+# /leetcode — Scaffold a LeetCode Problem
 
-Scaffold a new LeetCode/NeetCode problem in this SwiftChallenges Xcode project. Generates a solution stub and an empty XCTest file, then inserts both into `SwiftChallenges.xcodeproj/project.pbxproj` so Xcode picks them up automatically.
+Scaffold a new LeetCode problem in this SwiftChallenges Xcode project. Generates a solution stub and an empty XCTest file, then inserts both into `SwiftChallenges.xcodeproj/project.pbxproj` so Xcode picks them up automatically.
 
 ## Arguments
 
@@ -13,17 +13,19 @@ Scaffold a new LeetCode/NeetCode problem in this SwiftChallenges Xcode project. 
 
 ### Form A — Auto-resolve from problem identity (preferred)
 - `problem=<identifier>` — accepts a problem number, name, URL slug, or combined (e.g. `problem="46. Permutations"`, `problem="permutations"`, `problem=46`).
+- `prefix=<string>` — optional. If provided and non-empty, prepend it to the class name (e.g. `prefix="Neet"` → `NeetPermutations`). If omitted or empty, use the bare PascalCase name (e.g. `Permutations`).
 
 When `problem=` is provided, use your training knowledge to resolve:
-- `class` — PascalCase class name prefixed with `Neet` (e.g. `NeetPermutations`)
-- `group` — NeetCode category folder (e.g. `Backtracking`, `Trees`, `SlidingWindow`)
+- `class` — PascalCase class name, then apply prefix if set (e.g. `Permutations` → `NeetPermutations` when `prefix="Neet"`)
+- `group` — category folder (e.g. `Backtracking`, `Trees`, `SlidingWindow`)
 - `signature` — the exact LeetCode Swift function signature (e.g. `func permute(_ nums: [Int]) -> [[Int]]`)
 
 Use `signature` in the solution template (Step 3) instead of `func solve()`.
 
 ### Form B — Explicit (fallback)
-- `class=<ClassName>` — solution class & filename (no `.swift` suffix). PascalCase, prefixed with `Neet`.
-- `group=<Category>` — NeetCode category folder name.
+- `class=<ClassName>` — solution class & filename (no `.swift` suffix). PascalCase; include any desired prefix in the name itself, or use `prefix=` to have it applied automatically.
+- `group=<Category>` — category folder name.
+- `prefix=<string>` — optional. If provided and non-empty, prepend it to `class`.
 
 When using Form B, use `func solve()` as the placeholder signature.
 
@@ -35,7 +37,7 @@ If `$ARGUMENTS` provides neither `problem=` nor both `class=` and `group=`, abor
 
 ### 1. Parse and validate arguments
 
-Extract `class`, `group` from `$ARGUMENTS`. Both are required. Derive `test = "${class}Test"` — never accept it from the user.
+Extract `class`, `group`, and optional `prefix` from `$ARGUMENTS`. `class` and `group` are required. If `prefix` is provided and non-empty, prepend it to `class` now (e.g. `class = prefix + class`). Derive `test = "${class}Test"` — never accept it from the user.
 
 Verify both directories exist:
 - `SwiftChallenges/NeetCode/$group/`

--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -630,6 +630,9 @@
 		80AEC4241B9CAAA3CC9D88E5 /* NeetCombinationSum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */; };
 		983B56C59FB0CFEAAB31BC77 /* NeetCombinationSum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */; };
 		300507A1AB042E17EC79420A /* NeetCombinationSumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9720A5ACDA71E699F8A573D /* NeetCombinationSumTest.swift */; };
+		6D53331E61E7DE60A9E62603 /* NeetWordSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06ECA24A5B5B8EA3B921D438 /* NeetWordSearch.swift */; };
+		6C1EA81F99E094CEF9C0EFD0 /* NeetWordSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06ECA24A5B5B8EA3B921D438 /* NeetWordSearch.swift */; };
+		41356772048714174E1BD356 /* NeetWordSearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C61C027AA7AD0B4D36FE811 /* NeetWordSearchTest.swift */; };
 		FB1DFB7E2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB7F2FCFD94B00692126 /* ContinuousSubarraySum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */; };
 		FB1DFB812FCFD98D00692126 /* ContinuousSubarraySumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */; };
@@ -1156,6 +1159,8 @@
 		4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetPermutationsTest.swift; sourceTree = "<group>"; };
 		A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetCombinationSum.swift; sourceTree = "<group>"; };
 		D9720A5ACDA71E699F8A573D /* NeetCombinationSumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetCombinationSumTest.swift; sourceTree = "<group>"; };
+		06ECA24A5B5B8EA3B921D438 /* NeetWordSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetWordSearch.swift; sourceTree = "<group>"; };
+		0C61C027AA7AD0B4D36FE811 /* NeetWordSearchTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetWordSearchTest.swift; sourceTree = "<group>"; };
 		FB1DFB7D2FCFD94B00692126 /* ContinuousSubarraySum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySum.swift; sourceTree = "<group>"; };
 		FB1DFB802FCFD98D00692126 /* ContinuousSubarraySumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousSubarraySumTest.swift; sourceTree = "<group>"; };
 		FB2C5DA72FD3FB2B009550A1 /* SubarraySumEqualsK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubarraySumEqualsK.swift; sourceTree = "<group>"; };
@@ -2304,6 +2309,7 @@
 				FB1543C42FDFB21E00697F86 /* NeetSubsets.swift */,
 				D8315683B66F55C64F9E2944 /* NeetPermutations.swift */,
 				A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */,
+				06ECA24A5B5B8EA3B921D438 /* NeetWordSearch.swift */,
 			);
 			path = Backtracking;
 			sourceTree = "<group>";
@@ -2314,6 +2320,7 @@
 				FB1543C72FDFB27300697F86 /* NeetSubsetsTest.swift */,
 				4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */,
 				D9720A5ACDA71E699F8A573D /* NeetCombinationSumTest.swift */,
+				0C61C027AA7AD0B4D36FE811 /* NeetWordSearchTest.swift */,
 			);
 			path = Backtracking;
 			sourceTree = "<group>";
@@ -2787,6 +2794,7 @@
 				FB1543C52FDFB21E00697F86 /* NeetSubsets.swift in Sources */,
 				42D58F7AD3D74ED4B6C3A75A /* NeetPermutations.swift in Sources */,
 				80AEC4241B9CAAA3CC9D88E5 /* NeetCombinationSum.swift in Sources */,
+				6D53331E61E7DE60A9E62603 /* NeetWordSearch.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3152,6 +3160,7 @@
 				FB1543C62FDFB21E00697F86 /* NeetSubsets.swift in Sources */,
 				AF91A075B7BC0A1FDE3199EE /* NeetPermutations.swift in Sources */,
 				983B56C59FB0CFEAAB31BC77 /* NeetCombinationSum.swift in Sources */,
+				6C1EA81F99E094CEF9C0EFD0 /* NeetWordSearch.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,
@@ -3409,6 +3418,7 @@
 				FB1543C82FDFB27300697F86 /* NeetSubsetsTest.swift in Sources */,
 				C666BD0812BA8EB22B4D26BE /* NeetPermutationsTest.swift in Sources */,
 				300507A1AB042E17EC79420A /* NeetCombinationSumTest.swift in Sources */,
+				41356772048714174E1BD356 /* NeetWordSearchTest.swift in Sources */,
 				DECCF08A27FD8ED6007BA99C /* GoalParserTest.swift in Sources */,
 				DED795C4284A06CA005EF2E7 /* TrieTest.swift in Sources */,
 				DECCEF8D27FCF9C1007BA99C /* EvenNumberDigitsTest.swift in Sources */,

--- a/SwiftChallenges/NeetCode/Backtracking/NeetWordSearch.swift
+++ b/SwiftChallenges/NeetCode/Backtracking/NeetWordSearch.swift
@@ -53,9 +53,10 @@ class NeetWordSearch {
     }
 
     // Alternative: same algorithm but tracks visited cells in a Set instead of
-    // mutating the board. Trade-off: board stays immutable (no var copy needed),
-    // but visited lookup/insert/remove are O(1) with a small constant overhead,
-    // and Space grows to O(L) for the set on top of O(L) for the call stack.
+    // mutating the board. Board stays immutable; Set ops are O(1) avg.
+    //
+    // Time:  O(m * n * 4^L)  — same traversal as above; Set lookup is O(1) avg so no change
+    // Space: O(L)             — call stack O(L) + visited set holds at most L entries at once
     func exist(_ board: [[Character]], _ word: String) -> Bool {
         let rows = board.count
         let cols = board[0].count

--- a/SwiftChallenges/NeetCode/Backtracking/NeetWordSearch.swift
+++ b/SwiftChallenges/NeetCode/Backtracking/NeetWordSearch.swift
@@ -1,0 +1,91 @@
+//
+//  NeetWordSearch.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/19/26.
+//  https://leetcode.com/problems/word-search/
+
+// Strategy: DFS + backtracking. Try every cell as a starting point; recursively
+// explore all 4 neighbors. Mark visited cells in-place to avoid reuse, then
+// restore them on the way back up (backtrack).
+//
+// Time:  O(m * n * 4^L)  — m*n starting cells, each branching up to 4 ways for L chars
+// Space: O(L)             — recursion depth equals word length (no extra data structures)
+class NeetWordSearch {
+
+    func existsWithoutSet(_ board: [[Character]], _ word: String) -> Bool {
+        var board = board  // local copy so we can mutate for visited-marking
+        let rows = board.count
+        let cols = board[0].count
+        let chars = Array(word)  // O(1) index access vs String subscript
+        // i = index of the character in `word` we're currently trying to match
+        func dfs(_ r: Int, _ c: Int, _ i: Int) -> Bool {
+            // Base case: matched every character — word found
+            if i == chars.count { return true }
+            // Pruning: out of bounds, or current cell doesn't match next needed char
+            // (board[r][c] == "#" is also caught here since "#" ≠ any letter)
+            if r < 0 ||
+                r >= rows ||
+                c < 0 ||
+                c >= cols ||
+                board[r][c] != chars[i] {
+                return false
+            }
+            // Mark visited by overwriting with a sentinel that can't appear in a word
+            let tmp = board[r][c]
+            board[r][c] = "#"
+            // Explore all 4 directions; short-circuits as soon as any path succeeds
+            let found = dfs(r+1, c, i+1) ||
+            dfs(r-1, c, i+1) ||
+            dfs(r, c+1, i+1) ||
+            dfs(r, c-1, i+1)
+            // Backtrack: restore cell so other starting points can use it
+            board[r][c] = tmp
+            return found
+        }
+        // Try every cell as a potential start of the word
+        for r in 0..<rows {
+            for c in 0..<cols {
+                if dfs(r, c, 0) { return true }
+            }
+        }
+        return false
+    }
+
+    // Alternative: same algorithm but tracks visited cells in a Set instead of
+    // mutating the board. Trade-off: board stays immutable (no var copy needed),
+    // but visited lookup/insert/remove are O(1) with a small constant overhead,
+    // and Space grows to O(L) for the set on top of O(L) for the call stack.
+    func exist(_ board: [[Character]], _ word: String) -> Bool {
+        let rows = board.count
+        let cols = board[0].count
+        let chars = Array(word)
+        var visited = Set<[Int]>()  // stores [r, c] pairs for cells on the current path
+
+        func dfs(_ r: Int, _ c: Int, _ i: Int) -> Bool {
+            if i == chars.count { return true }
+            if r < 0 ||
+                r >= rows ||
+                c < 0 ||
+                c >= cols ||
+                board[r][c] != chars[i] ||
+                visited.contains([r, c]) {  // replaces the "#" sentinel check
+                return false
+            }
+            visited.insert([r, c])  // mark before recursing
+            let found = dfs(r+1, c, i+1) ||
+                dfs(r-1, c, i+1) ||
+                dfs(r, c+1, i+1) ||
+                dfs(r, c-1, i+1)
+            visited.remove([r, c])  // unmark on the way back up (backtrack)
+            return found
+        }
+
+        for r in 0..<rows {
+            for c in 0..<cols {
+                if dfs(r, c, 0) { return true }
+            }
+        }
+        return false
+    }
+}

--- a/SwiftChallengesTests/NeetCode/Backtracking/NeetWordSearchTest.swift
+++ b/SwiftChallengesTests/NeetCode/Backtracking/NeetWordSearchTest.swift
@@ -1,0 +1,67 @@
+//
+//  NeetWordSearchTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/19/26.
+//
+
+import XCTest
+
+class NeetWordSearchTest: XCTestCase {
+
+    private let sut = NeetWordSearch()
+
+    private func verify(_ board: [[Character]], _ word: String, file: StaticString = #file, line: UInt = #line) -> Bool {
+        sut.exist(board, word)
+    }
+
+    // MARK: - Base cases
+
+    func testSingleCellMatch() {
+        XCTAssertTrue(verify([["A"]], "A"))
+    }
+
+    func testSingleCellNoMatch() {
+        XCTAssertFalse(verify([["A"]], "B"))
+    }
+
+    func testWordLongerThanBoard() {
+        XCTAssertFalse(verify([["A", "B"], ["C", "D"]], "ABCDE"))
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        let board: [[Character]] = [["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]]
+        XCTAssertTrue(verify(board, "ABCCED"))
+    }
+
+    func testExample2() {
+        let board: [[Character]] = [["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]]
+        XCTAssertTrue(verify(board, "SEE"))
+    }
+
+    func testExample3() {
+        let board: [[Character]] = [["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]]
+        XCTAssertFalse(verify(board, "ABCB"))
+    }
+
+    // MARK: - Edge cases
+
+    func testWordNotInBoard() {
+        // "ABCD": A→B is fine, but B's only unvisited neighbor is D, not C — no path exists
+        XCTAssertFalse(verify([["A","B"],["C","D"]], "ABCD"))
+    }
+
+    func testNoCellReuse() {
+        XCTAssertFalse(verify([["A","A"]], "AAA"))
+    }
+
+    func testSingleRowWord() {
+        XCTAssertTrue(verify([["A","B","C"]], "ABC"))
+    }
+
+    func testWordInReverse() {
+        XCTAssertTrue(verify([["A","B","C"]], "CBA"))
+    }
+}


### PR DESCRIPTION
## Summary
- Implements LeetCode 79. Word Search with two approaches: in-place board mutation (`#` sentinel) and explicit `Set<[Int]>` visited tracking
- Adds educational comments covering strategy, time/space complexity, and key decisions at each step
- Fixes incorrect `testWordNotInBoard` test case (`"ABDC"` is actually reachable on the test board; replaced with `"ABCD"`)
- Updates `/leetcode` skill to remove hardcoded `Neet` prefix and add optional `prefix=` parameter

## Test plan
- [x] Cmd+B in Xcode confirms clean build
- [x] Run `NeetWordSearchTest` — all tests pass once `exist()` is implemented
- [x] Verify `testWordNotInBoard` correctly asserts false for `"ABCD"` on a 2×2 board

🤖 Generated with [Claude Code](https://claude.com/claude-code)