### PR TITLE
Add NQueens solution and unit tests (#134)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -737,6 +737,9 @@
 		FBB267622F95F19500CF0DB9 /* MinimumWindowSubstring.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB267612F95F19500CF0DB9 /* MinimumWindowSubstring.swift */; };
 		FBB267632F95F19500CF0DB9 /* MinimumWindowSubstring.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB267612F95F19500CF0DB9 /* MinimumWindowSubstring.swift */; };
 		FBB267672F95F21000CF0DB9 /* MinimumWindowSubstringTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB267662F95F21000CF0DB9 /* MinimumWindowSubstringTest.swift */; };
+		78B7DE8BDF99C83BB9D8F0D2 /* NQueens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A13D9047AF1BCEE4A199BA /* NQueens.swift */; };
+		C4325E122A06A582C52E4D17 /* NQueens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A13D9047AF1BCEE4A199BA /* NQueens.swift */; };
+		F64F78A49BC31AD17B88DAAA /* NQueensTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB73CCAFE1AF0FB83123405 /* NQueensTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1230,6 +1233,8 @@
 		FBB2675F2F959B2100CF0DB9 /* LengthOfLongestSubstringTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LengthOfLongestSubstringTest.swift; sourceTree = "<group>"; };
 		FBB267612F95F19500CF0DB9 /* MinimumWindowSubstring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumWindowSubstring.swift; sourceTree = "<group>"; };
 		FBB267662F95F21000CF0DB9 /* MinimumWindowSubstringTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumWindowSubstringTest.swift; sourceTree = "<group>"; };
+		03A13D9047AF1BCEE4A199BA /* NQueens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NQueens.swift; sourceTree = "<group>"; };
+		6AB73CCAFE1AF0FB83123405 /* NQueensTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NQueensTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2310,6 +2315,7 @@
 				D8315683B66F55C64F9E2944 /* NeetPermutations.swift */,
 				A8F70BC4CD3240AB976E47B2 /* NeetCombinationSum.swift */,
 				06ECA24A5B5B8EA3B921D438 /* NeetWordSearch.swift */,
+				03A13D9047AF1BCEE4A199BA /* NQueens.swift */,
 			);
 			path = Backtracking;
 			sourceTree = "<group>";
@@ -2321,6 +2327,7 @@
 				4EAB9708B00CC8B7024BF233 /* NeetPermutationsTest.swift */,
 				D9720A5ACDA71E699F8A573D /* NeetCombinationSumTest.swift */,
 				0C61C027AA7AD0B4D36FE811 /* NeetWordSearchTest.swift */,
+				6AB73CCAFE1AF0FB83123405 /* NQueensTest.swift */,
 			);
 			path = Backtracking;
 			sourceTree = "<group>";
@@ -2795,6 +2802,7 @@
 				42D58F7AD3D74ED4B6C3A75A /* NeetPermutations.swift in Sources */,
 				80AEC4241B9CAAA3CC9D88E5 /* NeetCombinationSum.swift in Sources */,
 				6D53331E61E7DE60A9E62603 /* NeetWordSearch.swift in Sources */,
+				78B7DE8BDF99C83BB9D8F0D2 /* NQueens.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3161,6 +3169,8 @@
 				AF91A075B7BC0A1FDE3199EE /* NeetPermutations.swift in Sources */,
 				983B56C59FB0CFEAAB31BC77 /* NeetCombinationSum.swift in Sources */,
 				6C1EA81F99E094CEF9C0EFD0 /* NeetWordSearch.swift in Sources */,
+				C4325E122A06A582C52E4D17 /* NQueens.swift in Sources */,
+				F64F78A49BC31AD17B88DAAA /* NQueensTest.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,

--- a/SwiftChallenges/NeetCode/Backtracking/NQueens.swift
+++ b/SwiftChallenges/NeetCode/Backtracking/NQueens.swift
@@ -1,0 +1,54 @@
+//
+//  NQueens.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/19/26.
+//  https://leetcode.com/problems/n-queens/
+
+class NQueens {
+
+    func solveNQueens(_ n: Int) -> [[String]] {
+        var result: [[String]] = []
+        var cols = Set<Int>()    // columns already occupied by a queen
+        var negDiag = Set<Int>()   // (row - col) uniquely identifies each top-left→bottom-right diagonal
+        var posDiag = Set<Int>()   // (row + col) uniquely identifies each top-right→bottom-left diagonal
+        var board = [Int](repeating: 0, count: n)  // board[row] = column where queen is placed
+
+        func backtrack(_ row: Int) {
+            // All rows filled — convert column indices to board strings and record the solution
+            if row == n {
+                result.append(board.map { col in
+                    String(repeating: ".", count: col) +
+                    "Q" +
+                    String(repeating: ".", count: n - col - 1)
+                })
+                return
+            }
+
+            for col in 0..<n {
+                // Skip if this column or either diagonal is already under attack
+                if cols.contains(col) ||
+                    negDiag.contains(row - col) ||
+                    posDiag.contains(row + col) {
+                    continue
+                }
+
+                // Place queen: mark column and both diagonals as occupied
+                cols.insert(col)
+                negDiag.insert(row - col)
+                posDiag.insert(row + col)
+                board[row] = col
+
+                backtrack(row + 1)
+
+                // Remove queen: unmark so other branches can reuse this position
+                cols.remove(col)
+                negDiag.remove(row - col)
+                posDiag.remove(row + col)
+            }
+        }
+
+        backtrack(0)
+        return result
+    }
+}

--- a/SwiftChallengesTests/NeetCode/Backtracking/NQueensTest.swift
+++ b/SwiftChallengesTests/NeetCode/Backtracking/NQueensTest.swift
@@ -1,0 +1,80 @@
+//
+//  NQueensTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/19/26.
+//
+
+import XCTest
+
+class NQueensTest: XCTestCase {
+
+    private let sut = NQueens()
+
+    private func sorted(_ boards: [[String]]) -> [[String]] {
+        boards.sorted { $0.joined() < $1.joined() }
+    }
+
+    private func verify(_ n: Int, expected: [[String]], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sorted(sut.solveNQueens(n)), sorted(expected), file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testN1() {
+        verify(1, expected: [["Q"]])
+    }
+
+    func testN2NoSolution() {
+        verify(2, expected: [])
+    }
+
+    func testN3NoSolution() {
+        verify(3, expected: [])
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify(4, expected: [
+            [".Q..","...Q","Q...","..Q."],
+            ["..Q.","Q...","...Q",".Q.."]
+        ])
+    }
+
+    // MARK: - Edge cases
+
+    func testN4Count() {
+        XCTAssertEqual(sut.solveNQueens(4).count, 2)
+    }
+
+    func testN5Count() {
+        XCTAssertEqual(sut.solveNQueens(5).count, 10)
+    }
+
+    func testN6Count() {
+        XCTAssertEqual(sut.solveNQueens(6).count, 4)
+    }
+
+    func testN8Count() {
+        XCTAssertEqual(sut.solveNQueens(8).count, 92)
+    }
+
+    func testBoardDimensions() {
+        let result = sut.solveNQueens(4)
+        for board in result {
+            XCTAssertEqual(board.count, 4)
+            for row in board {
+                XCTAssertEqual(row.count, 4)
+            }
+        }
+    }
+
+    func testEachRowHasExactlyOneQueen() {
+        for board in sut.solveNQueens(5) {
+            for row in board {
+                XCTAssertEqual(row.filter { $0 == "Q" }.count, 1)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements N-Queens backtracking solution using sets for O(1) column and diagonal conflict checks
- Adds full XCTest suite covering base cases, LeetCode examples, and edge cases (counts for n=4,5,6,8)

## Test plan
- [x] Cmd+B in Xcode — build clean
- [x] Run `NQueensTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)