### PR TITLE
Add CourseScheduleII solution and unit tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -743,6 +743,9 @@
 		0740FC6E87029AD5DAB42D15 /* CourseSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C486AA15563A4867D9BC9F85 /* CourseSchedule.swift */; };
 		2E08EA691A439166BD444F41 /* CourseSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C486AA15563A4867D9BC9F85 /* CourseSchedule.swift */; };
 		A9DF4F00DE64824847225696 /* CourseScheduleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E181B1F037357A5000CB8013 /* CourseScheduleTest.swift */; };
+		CDFF2922FF86E401EA420FE6 /* CourseScheduleII.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */; };
+		4554A0F9C4521E6A3FD68803 /* CourseScheduleII.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */; };
+		C663984AD8EEE905406C696B /* CourseScheduleIITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4F3D523932B031873AAC3F /* CourseScheduleIITest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1240,6 +1243,8 @@
 		6AB73CCAFE1AF0FB83123405 /* NQueensTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NQueensTest.swift; sourceTree = "<group>"; };
 		C486AA15563A4867D9BC9F85 /* CourseSchedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSchedule.swift; sourceTree = "<group>"; };
 		E181B1F037357A5000CB8013 /* CourseScheduleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseScheduleTest.swift; sourceTree = "<group>"; };
+		F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseScheduleII.swift; sourceTree = "<group>"; };
+		DB4F3D523932B031873AAC3F /* CourseScheduleIITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseScheduleIITest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2627,6 +2632,7 @@
 			isa = PBXGroup;
 			children = (
 				C486AA15563A4867D9BC9F85 /* CourseSchedule.swift */,
+				F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */,
 			);
 			path = TopologicalSort;
 			sourceTree = "<group>";
@@ -2635,6 +2641,7 @@
 			isa = PBXGroup;
 			children = (
 				E181B1F037357A5000CB8013 /* CourseScheduleTest.swift */,
+				DB4F3D523932B031873AAC3F /* CourseScheduleIITest.swift */,
 			);
 			path = TopologicalSort;
 			sourceTree = "<group>";
@@ -2827,6 +2834,7 @@
 				6D53331E61E7DE60A9E62603 /* NeetWordSearch.swift in Sources */,
 				78B7DE8BDF99C83BB9D8F0D2 /* NQueens.swift in Sources */,
 				0740FC6E87029AD5DAB42D15 /* CourseSchedule.swift in Sources */,
+				CDFF2922FF86E401EA420FE6 /* CourseScheduleII.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3197,6 +3205,8 @@
 				F64F78A49BC31AD17B88DAAA /* NQueensTest.swift in Sources */,
 				2E08EA691A439166BD444F41 /* CourseSchedule.swift in Sources */,
 				A9DF4F00DE64824847225696 /* CourseScheduleTest.swift in Sources */,
+				4554A0F9C4521E6A3FD68803 /* CourseScheduleII.swift in Sources */,
+				C663984AD8EEE905406C696B /* CourseScheduleIITest.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,

--- a/SwiftChallenges/NeetCode/TopologicalSort/CourseScheduleII.swift
+++ b/SwiftChallenges/NeetCode/TopologicalSort/CourseScheduleII.swift
@@ -1,0 +1,69 @@
+//
+//  CourseScheduleII.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/24/26.
+//  https://leetcode.com/problems/course-schedule-ii
+
+class CourseScheduleII {
+
+    func findOrder(_ numCourses: Int, _ prerequisites: [[Int]]) -> [Int] {
+        // Build adjacency list: course → list of its prerequisites
+        var adjacencyList = [Int: [Int]]()
+        for course in 0..<numCourses {
+            adjacencyList[course] = []
+        }
+
+        // Each pair [course, prereq] means "to take course, you must first take prereq"
+        for pair in prerequisites {
+            let course = pair[0]
+            let prereq = pair[1]
+            adjacencyList[course]!.append(prereq)
+        }
+
+        // Tracks nodes in the current DFS path — a revisit means a cycle
+        var currentPath = Set<Int>()
+        // Tracks nodes that are fully processed, so we never redo work for them
+        var visited = Set<Int>()
+        // Builds up in post-order: a course is appended only after all its prereqs are
+        var order = [Int]()
+
+        // Returns false the moment a cycle is detected, true otherwise
+        func dfs(_ course: Int) -> Bool {
+            // Already fully resolved on an earlier call — nothing left to do
+            if visited.contains(course) {
+                return true
+            }
+            // Found a node already being explored higher up this same DFS branch — cycle
+            if currentPath.contains(course) {
+                return false
+            }
+
+            // Mark this course as "in progress" for cycle detection
+            currentPath.insert(course)
+            // Resolve every prerequisite before this course can be considered done
+            for prereq in adjacencyList[course]! {
+                if !dfs(prereq) {
+                    return false
+                }
+            }
+            // Done exploring this branch — no longer "in progress"
+            currentPath.remove(course)
+            // Mark complete so future calls can skip straight past it
+            visited.insert(course)
+            // All prereqs are already in `order`, so it's now safe to append this course
+            order.append(course)
+            return true
+        }
+
+        // Run DFS from every course; memoization (`visited`) means already-processed
+        // courses short-circuit immediately when reached again from another branch
+        for course in 0..<numCourses {
+            if !dfs(course) {
+                // Cycle found somewhere in the graph — no valid order exists
+                return []
+            }
+        }
+        return order
+    }
+}

--- a/SwiftChallengesTests/NeetCode/TopologicalSort/CourseScheduleIITest.swift
+++ b/SwiftChallengesTests/NeetCode/TopologicalSort/CourseScheduleIITest.swift
@@ -1,0 +1,88 @@
+//
+//  CourseScheduleIITest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/24/26.
+//
+
+import XCTest
+
+class CourseScheduleIITest: XCTestCase {
+
+    private let sut = CourseScheduleII()
+
+    // Topological order isn't unique, so we can't compare against one fixed expected
+    // array. Instead, check the result is a complete permutation of all courses AND
+    // that every prerequisite appears before the course that depends on it.
+    private func isValidOrder(_ order: [Int], numCourses: Int, prerequisites: [[Int]]) -> Bool {
+        // Must contain every course exactly once
+        guard order.count == numCourses, Set(order) == Set(0..<numCourses) else { return false }
+        // Map each course to its index in the order, so we can compare positions
+        var position = [Int: Int]()
+        for (index, course) in order.enumerated() {
+            position[course] = index
+        }
+        // For every [course, prereq] pair, prereq's position must come before course's
+        for prerequisite in prerequisites {
+            let course = prerequisite[0]
+            let prereq = prerequisite[1]
+            guard let coursePosition = position[course], let prereqPosition = position[prereq], prereqPosition < coursePosition else {
+                return false
+            }
+        }
+        return true
+    }
+
+    // When expectValidOrder is true, any correctly-ordered permutation passes.
+    // When false, the graph has a cycle, so the only correct result is an empty array.
+    private func verify(_ numCourses: Int, _ prerequisites: [[Int]], expectValidOrder: Bool, file: StaticString = #filePath, line: UInt = #line) {
+        let result = sut.findOrder(numCourses, prerequisites)
+        if expectValidOrder {
+            XCTAssertTrue(isValidOrder(result, numCourses: numCourses, prerequisites: prerequisites), file: file, line: line)
+        } else {
+            XCTAssertEqual(result, [], file: file, line: line)
+        }
+    }
+
+    // MARK: - Base cases
+
+    func testSingleCourseNoPrerequisites() {
+        verify(1, [], expectValidOrder: true)
+    }
+
+    func testMultipleCoursesNoPrerequisites() {
+        verify(3, [], expectValidOrder: true)
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify(2, [[1, 0]], expectValidOrder: true)
+    }
+
+    func testExample2() {
+        verify(4, [[1, 0], [2, 0], [3, 1], [3, 2]], expectValidOrder: true)
+    }
+
+    func testExample3() {
+        verify(1, [], expectValidOrder: true)
+    }
+
+    // MARK: - Edge cases
+
+    func testTwoCourseCycleReturnsEmpty() {
+        verify(2, [[1, 0], [0, 1]], expectValidOrder: false)
+    }
+
+    func testLargerCycleReturnsEmpty() {
+        verify(3, [[1, 0], [2, 1], [0, 2]], expectValidOrder: false)
+    }
+
+    func testDisconnectedComponents() {
+        verify(5, [[1, 0], [3, 2]], expectValidOrder: true)
+    }
+
+    func testChainOfPrerequisites() {
+        verify(4, [[1, 0], [2, 1], [3, 2]], expectValidOrder: true)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds DFS-based topological sort solution for LeetCode 210 (Course Schedule II) in the existing `TopologicalSort` category
- Cycle detection via `currentPath`, memoization via `visited`, result built in post-order
- 9 unit tests covering base cases, LeetCode examples, and edge cases (cycles, disconnected components, chains)

## Test plan
- [x] `xcodebuild test` on `CourseScheduleIITest` — all 9 tests pass