### PR TITLE
Add MinimumHeightTrees solution and unit tests (#137)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -746,6 +746,9 @@
 		CDFF2922FF86E401EA420FE6 /* CourseScheduleII.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */; };
 		4554A0F9C4521E6A3FD68803 /* CourseScheduleII.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */; };
 		C663984AD8EEE905406C696B /* CourseScheduleIITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4F3D523932B031873AAC3F /* CourseScheduleIITest.swift */; };
+		2A6D873ED4D31E90FD57D7B1 /* MinimumHeightTrees.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F10FC5CB9E4AA24324C8C7B /* MinimumHeightTrees.swift */; };
+		31AFD0D7E15C015BE42432C5 /* MinimumHeightTrees.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F10FC5CB9E4AA24324C8C7B /* MinimumHeightTrees.swift */; };
+		EC35B2CF4BBF0A0D652987EA /* MinimumHeightTreesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B65D97CC562070DB14EB8C /* MinimumHeightTreesTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1245,6 +1248,8 @@
 		E181B1F037357A5000CB8013 /* CourseScheduleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseScheduleTest.swift; sourceTree = "<group>"; };
 		F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseScheduleII.swift; sourceTree = "<group>"; };
 		DB4F3D523932B031873AAC3F /* CourseScheduleIITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseScheduleIITest.swift; sourceTree = "<group>"; };
+		6F10FC5CB9E4AA24324C8C7B /* MinimumHeightTrees.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumHeightTrees.swift; sourceTree = "<group>"; };
+		48B65D97CC562070DB14EB8C /* MinimumHeightTreesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumHeightTreesTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2633,6 +2638,7 @@
 			children = (
 				C486AA15563A4867D9BC9F85 /* CourseSchedule.swift */,
 				F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */,
+				6F10FC5CB9E4AA24324C8C7B /* MinimumHeightTrees.swift */,
 			);
 			path = TopologicalSort;
 			sourceTree = "<group>";
@@ -2642,6 +2648,7 @@
 			children = (
 				E181B1F037357A5000CB8013 /* CourseScheduleTest.swift */,
 				DB4F3D523932B031873AAC3F /* CourseScheduleIITest.swift */,
+				48B65D97CC562070DB14EB8C /* MinimumHeightTreesTest.swift */,
 			);
 			path = TopologicalSort;
 			sourceTree = "<group>";
@@ -2835,6 +2842,7 @@
 				78B7DE8BDF99C83BB9D8F0D2 /* NQueens.swift in Sources */,
 				0740FC6E87029AD5DAB42D15 /* CourseSchedule.swift in Sources */,
 				CDFF2922FF86E401EA420FE6 /* CourseScheduleII.swift in Sources */,
+				2A6D873ED4D31E90FD57D7B1 /* MinimumHeightTrees.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3207,6 +3215,8 @@
 				A9DF4F00DE64824847225696 /* CourseScheduleTest.swift in Sources */,
 				4554A0F9C4521E6A3FD68803 /* CourseScheduleII.swift in Sources */,
 				C663984AD8EEE905406C696B /* CourseScheduleIITest.swift in Sources */,
+				31AFD0D7E15C015BE42432C5 /* MinimumHeightTrees.swift in Sources */,
+				EC35B2CF4BBF0A0D652987EA /* MinimumHeightTreesTest.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,

--- a/SwiftChallenges/NeetCode/TopologicalSort/MinimumHeightTrees.swift
+++ b/SwiftChallenges/NeetCode/TopologicalSort/MinimumHeightTrees.swift
@@ -1,0 +1,132 @@
+//
+//  MinimumHeightTrees.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/24/26.
+//  https://leetcode.com/problems/minimum-height-trees/
+
+class MinimumHeightTrees {
+
+    // -------------------------------------------------------------------------
+    // Topological Sort — leaf trimming (iterative)
+    //
+    // Summary:
+    //   The MHT roots are always the 1 or 2 center nodes of the tree.
+    //   We find them by repeatedly removing the current leaf layer (nodes
+    //   with degree 1), like peeling an onion inward, until only the
+    //   center node(s) remain. This mirrors topological sort: leaves are
+    //   processed first, exposing new leaves each round.
+    //
+    // Time:  O(n) — each node and edge is processed at most once
+    // Space: O(n) — adjacency list stores all n nodes and their edges
+    // -------------------------------------------------------------------------
+    func findMinHeightTrees(_ n: Int, _ edges: [[Int]]) -> [Int] {
+        // A single node has no edges, so it is trivially the root
+        if n == 1 { return [0] }
+
+        // Build an undirected adjacency list using Sets so removal is O(1)
+        var adj: [Set<Int>] = Array(repeating: Set<Int>(), count: n)
+        for edge in edges {
+            adj[edge[0]].insert(edge[1])
+            adj[edge[1]].insert(edge[0])
+        }
+
+        // Seed the queue with all initial leaves (degree == 1)
+        var queue: [Int] = []
+        for node in 0..<n {
+            if adj[node].count == 1 {
+                queue.append(node)
+            }
+        }
+        var remaining = n  // tracks how many nodes haven't been trimmed yet
+
+        // Trim leaves layer by layer, like peeling an onion inward.
+        // The answer is always the 1 or 2 center nodes, so stop at 2.
+        while remaining > 2 {
+            var nextLeaves: [Int] = []
+
+            for leaf in queue {
+                // Each leaf has exactly one neighbor from array of set — disconnect them
+                let neighbor = adj[leaf].first!
+                adj[neighbor].remove(leaf)
+
+                // If the neighbor is now a leaf, it joins the next layer
+                if adj[neighbor].count == 1 {
+                    nextLeaves.append(neighbor)
+                }
+            }
+
+            // This entire layer of leaves has been removed
+            remaining -= queue.count
+            queue = nextLeaves
+        }
+
+        // Whatever is left (1 or 2 nodes) are the MHT roots
+        return queue
+    }
+
+    // -------------------------------------------------------------------------
+    // Alternative: DFS to find the diameter path, then return its center node(s)
+    //
+    // Summary:
+    //   The MHT roots are always the center(s) of the tree's longest path
+    //   (the diameter). We find the diameter with two DFS passes:
+    //     1. DFS from any node (0) → finds one end of the diameter (u)
+    //     2. DFS from u → finds the other end and records the full path
+    //   The middle 1 or 2 nodes of that path are the answer.
+    //
+    // Time:  O(n) — two DFS passes, each visits every node once
+    // Space: O(n) — adjacency list + recursion stack + path storage
+    // -------------------------------------------------------------------------
+    func findMinHeightTreesDFS(_ n: Int, _ edges: [[Int]]) -> [Int] {
+        if n == 1 { return [0] }
+
+        // Build undirected adjacency list
+        var adj: [[Int]] = Array(repeating: [], count: n)
+        for edge in edges {
+            adj[edge[0]].append(edge[1])
+            adj[edge[1]].append(edge[0])
+        }
+
+        // DFS that tracks the current path via backtracking.
+        // Keeps the longest path seen so far in bestPath.
+        func dfs(node: Int, parent: Int, currentPath: inout [Int], bestPath: inout [Int]) {
+            currentPath.append(node)
+
+            if currentPath.count > bestPath.count {
+                bestPath = currentPath
+            }
+
+            for neighbor in adj[node] {
+                // Skip the node we came from to avoid going backwards
+                if neighbor != parent {
+                    dfs(node: neighbor, parent: node, currentPath: &currentPath, bestPath: &bestPath)
+                }
+            }
+
+            // Backtrack: remove this node before returning to caller
+            currentPath.removeLast()
+        }
+
+        // Step 1: DFS from node 0 to find one end of the diameter
+        var currentPath: [Int] = []
+        var bestPath: [Int] = []
+        dfs(node: 0, parent: -1, currentPath: &currentPath, bestPath: &bestPath)
+        let diameterStart = bestPath.last!
+
+        // Step 2: DFS from that end to find the full diameter path
+        currentPath = []
+        bestPath = []
+        dfs(node: diameterStart, parent: -1, currentPath: &currentPath, bestPath: &bestPath)
+        let diameterPath = bestPath
+
+        // Step 3: The center of the diameter path is the MHT root(s).
+        // Odd-length path → 1 center; even-length path → 2 centers.
+        let len = diameterPath.count
+        if len % 2 == 1 {
+            return [diameterPath[len / 2]]
+        } else {
+            return [diameterPath[len / 2 - 1], diameterPath[len / 2]]
+        }
+    }
+}

--- a/SwiftChallengesTests/NeetCode/TopologicalSort/MinimumHeightTreesTest.swift
+++ b/SwiftChallengesTests/NeetCode/TopologicalSort/MinimumHeightTreesTest.swift
@@ -1,0 +1,53 @@
+//
+//  MinimumHeightTreesTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/24/26.
+//
+
+import XCTest
+
+class MinimumHeightTreesTest: XCTestCase {
+
+    private let sut = MinimumHeightTrees()
+
+    private func verify(_ n: Int, _ edges: [[Int]], _ expected: [Int], file: StaticString = #filePath, line: UInt = #line) {
+        let result = sut.findMinHeightTrees(n, edges)
+        XCTAssertEqual(Set(result), Set(expected), file: file, line: line)
+        XCTAssertEqual(result.count, expected.count, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testSingleNode() {
+        verify(1, [], [0])
+    }
+
+    func testTwoNodes() {
+        verify(2, [[0, 1]], [0, 1])
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify(4, [[1, 0], [1, 2], [1, 3]], [1])
+    }
+
+    func testExample2() {
+        verify(6, [[3, 0], [3, 1], [3, 2], [3, 4], [5, 4]], [3, 4])
+    }
+
+    // MARK: - Edge cases
+
+    func testStraightLine() {
+        verify(4, [[0, 1], [1, 2], [2, 3]], [1, 2])
+    }
+
+    func testStarShape() {
+        verify(5, [[0, 1], [0, 2], [0, 3], [0, 4]], [0])
+    }
+
+    func testThreeNodesLine() {
+        verify(3, [[0, 1], [1, 2]], [1])
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `findMinHeightTrees` using topological sort (iterative leaf trimming) — peels leaves layer by layer until the 1 or 2 center nodes remain
- Adds alternative `findMinHeightTreesDFS` using two DFS passes to find the tree diameter, then returns the center node(s) of that path
- Both functions include inline comments and a header with summary, time, and space complexity

## Test plan
- [x] Single node (n=1)
- [x] Two nodes
- [x] LeetCode example 1: star graph → [1]
- [x] LeetCode example 2: → [3, 4]
- [x] Straight line → [1, 2]
- [x] Star shape → [0]
- [x] Three nodes line → [1]

🤖 Generated with [Claude Code](https://claude.com/claude-code)