### PR TITLE
Add AlienDictionary solution and unit tests (#138)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -749,6 +749,9 @@
 		2A6D873ED4D31E90FD57D7B1 /* MinimumHeightTrees.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F10FC5CB9E4AA24324C8C7B /* MinimumHeightTrees.swift */; };
 		31AFD0D7E15C015BE42432C5 /* MinimumHeightTrees.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F10FC5CB9E4AA24324C8C7B /* MinimumHeightTrees.swift */; };
 		EC35B2CF4BBF0A0D652987EA /* MinimumHeightTreesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B65D97CC562070DB14EB8C /* MinimumHeightTreesTest.swift */; };
+		4CC40A3F01BD53EF83B55132 /* AlienDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED419E1B0637B7F53A952D58 /* AlienDictionary.swift */; };
+		99F30862844AE33CC11F771E /* AlienDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED419E1B0637B7F53A952D58 /* AlienDictionary.swift */; };
+		AC9388710BCB7029F4CC6810 /* AlienDictionaryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9DB499DFDC5DF017BEEC45 /* AlienDictionaryTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1250,6 +1253,8 @@
 		DB4F3D523932B031873AAC3F /* CourseScheduleIITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseScheduleIITest.swift; sourceTree = "<group>"; };
 		6F10FC5CB9E4AA24324C8C7B /* MinimumHeightTrees.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumHeightTrees.swift; sourceTree = "<group>"; };
 		48B65D97CC562070DB14EB8C /* MinimumHeightTreesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumHeightTreesTest.swift; sourceTree = "<group>"; };
+		ED419E1B0637B7F53A952D58 /* AlienDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlienDictionary.swift; sourceTree = "<group>"; };
+		7C9DB499DFDC5DF017BEEC45 /* AlienDictionaryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlienDictionaryTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2639,6 +2644,7 @@
 				C486AA15563A4867D9BC9F85 /* CourseSchedule.swift */,
 				F7A2D56E6D8F0F3FAB87B624 /* CourseScheduleII.swift */,
 				6F10FC5CB9E4AA24324C8C7B /* MinimumHeightTrees.swift */,
+				ED419E1B0637B7F53A952D58 /* AlienDictionary.swift */,
 			);
 			path = TopologicalSort;
 			sourceTree = "<group>";
@@ -2649,6 +2655,7 @@
 				E181B1F037357A5000CB8013 /* CourseScheduleTest.swift */,
 				DB4F3D523932B031873AAC3F /* CourseScheduleIITest.swift */,
 				48B65D97CC562070DB14EB8C /* MinimumHeightTreesTest.swift */,
+				7C9DB499DFDC5DF017BEEC45 /* AlienDictionaryTest.swift */,
 			);
 			path = TopologicalSort;
 			sourceTree = "<group>";
@@ -2843,6 +2850,7 @@
 				0740FC6E87029AD5DAB42D15 /* CourseSchedule.swift in Sources */,
 				CDFF2922FF86E401EA420FE6 /* CourseScheduleII.swift in Sources */,
 				2A6D873ED4D31E90FD57D7B1 /* MinimumHeightTrees.swift in Sources */,
+				4CC40A3F01BD53EF83B55132 /* AlienDictionary.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3217,6 +3225,8 @@
 				C663984AD8EEE905406C696B /* CourseScheduleIITest.swift in Sources */,
 				31AFD0D7E15C015BE42432C5 /* MinimumHeightTrees.swift in Sources */,
 				EC35B2CF4BBF0A0D652987EA /* MinimumHeightTreesTest.swift in Sources */,
+				99F30862844AE33CC11F771E /* AlienDictionary.swift in Sources */,
+				AC9388710BCB7029F4CC6810 /* AlienDictionaryTest.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,

--- a/SwiftChallenges/NeetCode/TopologicalSort/AlienDictionary.swift
+++ b/SwiftChallenges/NeetCode/TopologicalSort/AlienDictionary.swift
@@ -1,0 +1,110 @@
+//
+//  AlienDictionary.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 6/27/26.
+//
+
+// 269. Alien Dictionary
+//
+// There is a new alien language that uses the English alphabet. However, the
+// order of the letters is unknown to you.
+//
+// You are given a list of strings words from the alien language's dictionary,
+// where the strings in words are sorted lexicographically by the rules of
+// this new language.
+//
+// Return a string of the unique letters in the new alien language sorted in
+// lexicographically increasing order by the new language's rules. If there is
+// no solution, return "". If there are multiple solutions, return any of them.
+//
+// Example 1:
+//   Input:  words = ["wrt","wrf","er","ett","rftt"]
+//   Output: "wertf"
+//
+// Example 2:
+//   Input:  words = ["z","x"]
+//   Output: "zx"
+//
+// Example 3:
+//   Input:  words = ["z","x","z"]
+//   Output: ""
+//   Explanation: The order is invalid, so return "".
+//
+// Constraints:
+//   - 1 <= words.length <= 100
+//   - 1 <= words[i].length <= 100
+//   - words[i] consists of only lowercase English letters.
+
+class AlienDictionary {
+
+    // Derives the alien character ordering using post-order DFS topological sort.
+    //
+    // 1. Build an adjacency list by seeding every unique character, then comparing
+    //    each adjacent word pair to extract a "comes before" edge from the first
+    //    differing character. If a longer word is a prefix of the shorter one that
+    //    follows it, the input is invalid — return "".
+    //
+    // 2. Run post-order DFS over every character. The visit map encodes three states:
+    //      absent  → not yet visited
+    //      true    → currently on the DFS call stack (a revisit means a cycle)
+    //      false   → fully processed and already appended to result
+    //    Appending after all neighbors are resolved (post-order) means result ends
+    //    up in reverse topological order; reversing it at the end gives the answer.
+    //
+    // Time:  O(N * M) — N words, M max word length; the DFS is O(V + E) but V and E
+    //        are bounded by the alphabet size (≤ 26), so word scanning dominates.
+    // Space: O(V + E) — adjacency list, visit map, result, and DFS call stack are all
+    //        proportional to the number of unique characters and edges (≤ 26 and 26²).
+    func alienOrder(_ words: [String]) -> String {
+        // Seed every unique character so chars with no edges still appear in output
+        var adj = [Character: Set<Character>]()
+        for word in words {
+            for c in word { if adj[c] == nil { adj[c] = [] } }
+        }
+
+        // Extract one ordering edge per adjacent word pair
+        for i in 0..<words.count - 1 {
+            let w1 = Array(words[i])
+            let w2 = Array(words[i + 1])
+            let minLen = min(w1.count, w2.count)
+            // The problem guarantees words are sorted in alien order, so a longer word
+            // appearing before its own prefix directly contradicts that guarantee
+            if w1.count > w2.count && w1.prefix(minLen) == w2.prefix(minLen) {
+                return ""
+            }
+            for j in 0..<minLen where w1[j] != w2[j] {
+                adj[w1[j]]!.insert(w2[j])
+                break
+            }
+        }
+
+        // absent = unvisited, true = in current path (cycle if revisited), false = done
+        var visit = [Character: Bool]()
+        var result = [Character]()
+
+        // Returns false if a cycle is detected, true otherwise.
+        // Appends c to result after all its neighbors are processed (post-order),
+        // so result ends up in reverse topological order.
+        func dfs(_ c: Character) -> Bool {
+            if let inPath = visit[c] {
+                return !inPath
+            }
+            visit[c] = true
+            for neighbor in adj[c]! {
+                if !dfs(neighbor) {
+                    return false
+                }
+            }
+            visit[c] = false
+            result.append(c) // post-order: append after all descendants are resolved
+            return true
+        }
+
+        for c in adj.keys {
+            if !dfs(c) { return "" }
+        }
+
+        return String(result.reversed())
+    }
+}

--- a/SwiftChallengesTests/NeetCode/TopologicalSort/AlienDictionaryTest.swift
+++ b/SwiftChallengesTests/NeetCode/TopologicalSort/AlienDictionaryTest.swift
@@ -1,0 +1,82 @@
+//
+//  AlienDictionaryTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 6/27/26.
+//
+
+import XCTest
+
+class AlienDictionaryTest: XCTestCase {
+
+    private let sut = AlienDictionary()
+
+    private func isValidOrder(_ words: [String], _ order: String) -> Bool {
+        var rank = [Character: Int]()
+        for (i, c) in order.enumerated() { rank[c] = i }
+        for i in 0..<words.count - 1 {
+            let w1 = Array(words[i]), w2 = Array(words[i + 1])
+            var found = false
+            for j in 0..<min(w1.count, w2.count) {
+                guard let r1 = rank[w1[j]], let r2 = rank[w2[j]] else { return false }
+                if r1 < r2 { found = true; break }
+                if r1 > r2 { return false }
+            }
+            if !found && w1.count > w2.count { return false }
+        }
+        return true
+    }
+
+    private func verify(_ words: [String], file: StaticString = #file, line: UInt = #line) -> String {
+        sut.alienOrder(words)
+    }
+
+    // MARK: - Base cases
+
+    func testSingleWord() {
+        let result = verify(["abc"])
+        XCTAssertEqual(Set(result), Set("abc"))
+    }
+
+    func testSingleCharWord() {
+        XCTAssertEqual(verify(["a"]), "a")
+    }
+
+    func testTwoIdenticalWords() {
+        let result = verify(["z", "z"])
+        XCTAssertEqual(result, "z")
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        let words = ["wrt", "wrf", "er", "ett", "rftt"]
+        let result = verify(words)
+        XCTAssertTrue(isValidOrder(words, result), "Expected valid ordering, got: \(result)")
+        XCTAssertEqual(result.count, 5)
+    }
+
+    func testExample2() {
+        XCTAssertEqual(verify(["z", "x"]), "zx")
+    }
+
+    func testExample3() {
+        XCTAssertEqual(verify(["z", "x", "z"]), "")
+    }
+
+    // MARK: - Edge cases
+
+    func testPrefixAfterLongerWord() {
+        XCTAssertEqual(verify(["abc", "ab"]), "")
+    }
+
+    func testCycleDetection() {
+        XCTAssertEqual(verify(["b", "a", "b"]), "")
+    }
+
+    func testTwoLetterOrdering() {
+        let words = ["ba", "bc", "ac", "ca"]
+        let result = verify(words)
+        XCTAssertTrue(isValidOrder(words, result), "Expected valid ordering, got: \(result)")
+    }
+}


### PR DESCRIPTION
## Summary
- Implements LeetCode 269 (Alien Dictionary) using post-order DFS topological sort
- Adds adjacency list built from adjacent word pair comparisons with cycle detection via three-state visit map
- Includes full XCTest suite covering LeetCode examples, edge cases, and cycle/invalid input detection

## Test plan
- [x] Build succeeds in Xcode
- [x] All `AlienDictionaryTest` cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)