### PR TITLE
Add HouseRobber solution and unit tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -755,6 +755,9 @@
 		0C66A612E055B4B20E783C4D /* ClimbingStairs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88823EBAC9077A39CB52BEFB /* ClimbingStairs.swift */; };
 		608CC66C0F32D98632B7D764 /* ClimbingStairs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88823EBAC9077A39CB52BEFB /* ClimbingStairs.swift */; };
 		CAD21BCBEE5045CB0F72FE44 /* ClimbingStairsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0AECFF09758AB9CDB36558 /* ClimbingStairsTest.swift */; };
+		B27EC53E03379A14E1FF7108 /* HouseRobber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB140F0D32D3658B4853ECA /* HouseRobber.swift */; };
+		9098D5DE302D364CC06E757D /* HouseRobber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB140F0D32D3658B4853ECA /* HouseRobber.swift */; };
+		62F2FA0C66FCFE4006860F31 /* HouseRobberTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8911F1C9E7590CC01E1C576C /* HouseRobberTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1260,6 +1263,8 @@
 		7C9DB499DFDC5DF017BEEC45 /* AlienDictionaryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlienDictionaryTest.swift; sourceTree = "<group>"; };
 		88823EBAC9077A39CB52BEFB /* ClimbingStairs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimbingStairs.swift; sourceTree = "<group>"; };
 		6D0AECFF09758AB9CDB36558 /* ClimbingStairsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimbingStairsTest.swift; sourceTree = "<group>"; };
+		0EB140F0D32D3658B4853ECA /* HouseRobber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseRobber.swift; sourceTree = "<group>"; };
+		8911F1C9E7590CC01E1C576C /* HouseRobberTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseRobberTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2671,6 +2676,7 @@
 			isa = PBXGroup;
 			children = (
 				88823EBAC9077A39CB52BEFB /* ClimbingStairs.swift */,
+				0EB140F0D32D3658B4853ECA /* HouseRobber.swift */,
 			);
 			path = DynamicProgramming;
 			sourceTree = "<group>";
@@ -2679,6 +2685,7 @@
 			isa = PBXGroup;
 			children = (
 				6D0AECFF09758AB9CDB36558 /* ClimbingStairsTest.swift */,
+				8911F1C9E7590CC01E1C576C /* HouseRobberTest.swift */,
 			);
 			path = DynamicProgramming;
 			sourceTree = "<group>";
@@ -2875,6 +2882,7 @@
 				2A6D873ED4D31E90FD57D7B1 /* MinimumHeightTrees.swift in Sources */,
 				4CC40A3F01BD53EF83B55132 /* AlienDictionary.swift in Sources */,
 				0C66A612E055B4B20E783C4D /* ClimbingStairs.swift in Sources */,
+				B27EC53E03379A14E1FF7108 /* HouseRobber.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3253,6 +3261,8 @@
 				AC9388710BCB7029F4CC6810 /* AlienDictionaryTest.swift in Sources */,
 				608CC66C0F32D98632B7D764 /* ClimbingStairs.swift in Sources */,
 				CAD21BCBEE5045CB0F72FE44 /* ClimbingStairsTest.swift in Sources */,
+				9098D5DE302D364CC06E757D /* HouseRobber.swift in Sources */,
+				62F2FA0C66FCFE4006860F31 /* HouseRobberTest.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,

--- a/SwiftChallenges/NeetCode/DynamicProgramming/HouseRobber.swift
+++ b/SwiftChallenges/NeetCode/DynamicProgramming/HouseRobber.swift
@@ -1,0 +1,47 @@
+//
+//  HouseRobber.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/5/26.
+//
+
+class HouseRobber {
+
+    // BOTTOM-UP DP — O(n) time, O(1) space
+    // Builds the answer forward: solves house 0, then 1, then 2...
+    // Only needs the last two results, so no array required.
+    func rob(_ nums: [Int]) -> Int {
+        // prevPrev = best loot achievable before the previous house (0 initially)
+        // prev     = best loot achievable up to the previous house (0 initially)
+        var prevPrev = 0
+        var prev = 0
+        for n in nums {
+            // rob this house: prevPrev + n (skip previous to avoid triggering alarm)
+            // skip this house: prev carries forward unchanged
+            let best = max(prevPrev + n, prev)
+            prevPrev = prev  // slide window forward
+            prev = best
+        }
+        return prev
+    }
+
+    // TOP-DOWN DP (memoized recursion) — O(n) time, O(n) space
+    // Starts from house 0 and branches into two choices at each step.
+    // memo caches results so each house is only computed once.
+    func robV2(_ nums: [Int]) -> Int {
+        var memo = [Int: Int]()
+
+        func dfs(_ i: Int) -> Int {
+            if i >= nums.count { return 0 }        // past the last house
+            if let cached = memo[i] { return cached }
+
+            // choice 1: rob house i, then skip i+1 and recurse from i+2
+            // choice 2: skip house i, recurse from i+1
+            let result = max(nums[i] + dfs(i + 2), dfs(i + 1))
+            memo[i] = result
+            return result
+        }
+
+        return dfs(0)
+    }
+}

--- a/SwiftChallengesTests/NeetCode/DynamicProgramming/HouseRobberTest.swift
+++ b/SwiftChallengesTests/NeetCode/DynamicProgramming/HouseRobberTest.swift
@@ -1,0 +1,93 @@
+//
+//  HouseRobberTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/5/26.
+//
+
+import XCTest
+
+class HouseRobberTest: XCTestCase {
+
+    private let sut = HouseRobber()
+
+    private func verify(_ nums: [Int], _ expected: Int, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.rob(nums), expected, file: file, line: line)
+    }
+
+    private func verifyV2(_ nums: [Int], _ expected: Int, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.robV2(nums), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testEmpty() {
+        verify([], 0)
+    }
+
+    func testSingleHouse() {
+        verify([5], 5)
+    }
+
+    func testTwoHouses() {
+        verify([2, 7], 7)
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify([1, 2, 3, 1], 4)
+    }
+
+    func testExample2() {
+        verify([2, 7, 9, 3, 1], 12)
+    }
+
+    // MARK: - Edge cases
+
+    func testAllSameValues() {
+        verify([3, 3, 3, 3, 3], 9)
+    }
+
+    func testAlternatingHighLow() {
+        verify([10, 1, 10, 1, 10], 30)
+    }
+
+    func testLargerSkip() {
+        verify([5, 1, 1, 5], 10)
+    }
+
+    // MARK: - V2 (top-down)
+
+    func testV2Empty() {
+        verifyV2([], 0)
+    }
+
+    func testV2SingleHouse() {
+        verifyV2([5], 5)
+    }
+
+    func testV2TwoHouses() {
+        verifyV2([2, 7], 7)
+    }
+
+    func testV2Example1() {
+        verifyV2([1, 2, 3, 1], 4)
+    }
+
+    func testV2Example2() {
+        verifyV2([2, 7, 9, 3, 1], 12)
+    }
+
+    func testV2AllSameValues() {
+        verifyV2([3, 3, 3, 3, 3], 9)
+    }
+
+    func testV2AlternatingHighLow() {
+        verifyV2([10, 1, 10, 1, 10], 30)
+    }
+
+    func testV2LargerSkip() {
+        verifyV2([5, 1, 1, 5], 10)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds bottom-up DP solution (`rob`) with O(n) time, O(1) space
- Adds top-down memoized recursion solution (`robV2`) for comparison
- Unit tests cover base cases, both LeetCode examples, and edge cases for both implementations

## Test plan
- [ ] Cmd+B in Xcode — clean build
- [x] Run HouseRobberTest — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)