### PR TITLE
Add CoinChange solution and unit tests (#141)

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -758,6 +758,9 @@
 		B27EC53E03379A14E1FF7108 /* HouseRobber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB140F0D32D3658B4853ECA /* HouseRobber.swift */; };
 		9098D5DE302D364CC06E757D /* HouseRobber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB140F0D32D3658B4853ECA /* HouseRobber.swift */; };
 		62F2FA0C66FCFE4006860F31 /* HouseRobberTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8911F1C9E7590CC01E1C576C /* HouseRobberTest.swift */; };
+		35E1227AF475C356BC55155F /* CoinChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298AD4B33D6C05B7105E04A2 /* CoinChange.swift */; };
+		B8D9E334EFF34FC2B3049B61 /* CoinChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298AD4B33D6C05B7105E04A2 /* CoinChange.swift */; };
+		08F6CB7CF0E2CAE0A8A9C64C /* CoinChangeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C36F49BD6B9284D49C16C4E /* CoinChangeTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1265,6 +1268,8 @@
 		6D0AECFF09758AB9CDB36558 /* ClimbingStairsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimbingStairsTest.swift; sourceTree = "<group>"; };
 		0EB140F0D32D3658B4853ECA /* HouseRobber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseRobber.swift; sourceTree = "<group>"; };
 		8911F1C9E7590CC01E1C576C /* HouseRobberTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseRobberTest.swift; sourceTree = "<group>"; };
+		298AD4B33D6C05B7105E04A2 /* CoinChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinChange.swift; sourceTree = "<group>"; };
+		5C36F49BD6B9284D49C16C4E /* CoinChangeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinChangeTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2677,6 +2682,7 @@
 			children = (
 				88823EBAC9077A39CB52BEFB /* ClimbingStairs.swift */,
 				0EB140F0D32D3658B4853ECA /* HouseRobber.swift */,
+				298AD4B33D6C05B7105E04A2 /* CoinChange.swift */,
 			);
 			path = DynamicProgramming;
 			sourceTree = "<group>";
@@ -2686,6 +2692,7 @@
 			children = (
 				6D0AECFF09758AB9CDB36558 /* ClimbingStairsTest.swift */,
 				8911F1C9E7590CC01E1C576C /* HouseRobberTest.swift */,
+				5C36F49BD6B9284D49C16C4E /* CoinChangeTest.swift */,
 			);
 			path = DynamicProgramming;
 			sourceTree = "<group>";
@@ -2883,6 +2890,7 @@
 				4CC40A3F01BD53EF83B55132 /* AlienDictionary.swift in Sources */,
 				0C66A612E055B4B20E783C4D /* ClimbingStairs.swift in Sources */,
 				B27EC53E03379A14E1FF7108 /* HouseRobber.swift in Sources */,
+				35E1227AF475C356BC55155F /* CoinChange.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3263,6 +3271,8 @@
 				CAD21BCBEE5045CB0F72FE44 /* ClimbingStairsTest.swift in Sources */,
 				9098D5DE302D364CC06E757D /* HouseRobber.swift in Sources */,
 				62F2FA0C66FCFE4006860F31 /* HouseRobberTest.swift in Sources */,
+				B8D9E334EFF34FC2B3049B61 /* CoinChange.swift in Sources */,
+				08F6CB7CF0E2CAE0A8A9C64C /* CoinChangeTest.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,

--- a/SwiftChallenges/NeetCode/DynamicProgramming/CoinChange.swift
+++ b/SwiftChallenges/NeetCode/DynamicProgramming/CoinChange.swift
@@ -1,0 +1,121 @@
+//
+//  CoinChange.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/5/26.
+//
+
+// ============================================================
+// V1 — Bottom-up DP (Claude)
+// ============================================================
+// INTUITION: Build up answers for every sub-amount 0…amount.
+// To make change for X, try each coin and ask:
+//   "What if I use this coin? Then I need dp[X - coin] more coins."
+// Take the minimum across all coins.
+//
+// MEMORY AID: "dp[i] = fewest coins to make amount i"
+//
+// TIME:  O(amount × coins.count)
+// SPACE: O(amount)
+
+// ============================================================
+// V2 — Bottom-up DP (NeetCode style, translated from Python)
+// ============================================================
+// INTUITION (NeetCode's mental model):
+//
+//   Step 1 — Brute force / decision tree
+//     At each node of a tree you decide: which coin to use next?
+//     Every path from root to a "0-remaining" leaf is a valid solution.
+//     This is O(coins^amount) — way too slow.
+//
+//   Step 2 — Notice repeated sub-problems
+//     Different branches of the tree reach the same remaining amount.
+//     e.g. coins=[1,2,3], amount=4:
+//       pick 1 then 3  →  remaining=0  ✓
+//       pick 3 then 1  →  remaining=0  ✓  (same sub-problem!)
+//     Cache the answer the first time you compute it.
+//
+//   Step 3 — Flip it bottom-up (avoid recursion overhead)
+//     Instead of top-down recursion + cache, pre-fill a dp array
+//     from 0 up to amount.  Each cell reuses already-computed cells.
+//
+// KEY LINES (exactly what NeetCode codes in Python, now in Swift):
+//   var dp = Array(repeating: amount + 1, count: amount + 1)
+//   dp[0] = 0
+//   for a in 1...amount { for c in coins { if c <= a { dp[a] = min(dp[a], 1 + dp[a - c]) } } }
+//   return dp[amount] != amount + 1 ? dp[amount] : -1
+//
+// TIME:  O(amount × coins.count)
+// SPACE: O(amount)
+
+class CoinChange {
+
+    // V1 — my own bottom-up style
+    func coinChange(_ coins: [Int], _ amount: Int) -> Int {
+
+        // Use amount+1 as "infinity" — it's impossible to need more coins
+        // than the amount itself (you'd never need >amount 1-coins).
+        let infinity = amount + 1
+
+        // dp[i] = minimum coins needed to make exactly amount i.
+        // Start every entry as "impossible" except dp[0].
+        var dp = Array(repeating: infinity, count: amount + 1)
+
+        // Base case: zero coins are needed to make amount 0.
+        dp[0] = 0
+
+        // Guard: 1...0 is an invalid range in Swift and would crash.
+        guard amount > 0 else { return 0 }
+
+        // Fill dp[1] through dp[amount] one sub-problem at a time.
+        for i in 1...amount {
+            for coin in coins {
+                // Can only use this coin if it doesn't exceed the current amount.
+                if coin <= i {
+                    // Option A: don't use this coin → dp[i] (current best)
+                    // Option B: use this coin once → 1 + dp[i - coin]
+                    dp[i] = min(dp[i], 1 + dp[i - coin])
+                }
+            }
+        }
+
+        // If dp[amount] is still "infinity", no combination of coins works.
+        return dp[amount] == infinity ? -1 : dp[amount]
+    }
+
+    // V2 — NeetCode's bottom-up style (direct Swift translation of his Python)
+    func coinChangeV2(_ coins: [Int], _ amount: Int) -> Int {
+
+        // Initialize every slot to amount+1 ("infinity").
+        // NeetCode's reasoning: you'll never need more than `amount` coins,
+        // so amount+1 is safely unreachable — and no overflow risk.
+        var dp = Array(repeating: amount + 1, count: amount + 1)
+
+        // dp[0] = 0: base case — making change for 0 requires 0 coins.
+        dp[0] = 0
+
+        // Guard: 1...0 is an invalid range in Swift and would crash.
+        guard amount > 0 else { return 0 }
+
+        // Outer loop: solve every sub-amount from 1 up to the target.
+        // Think of `a` as "how much do I still need to make?"
+        for a in 1...amount {
+
+            // Inner loop: try every coin denomination.
+            for c in coins {
+
+                // Only valid if this coin doesn't overshoot the current amount.
+                if c <= a {
+                    // "If I use coin c once, I already solved dp[a - c].
+                    //  So the total cost is 1 + dp[a - c]."
+                    // Keep the minimum across all coin choices.
+                    dp[a] = min(dp[a], 1 + dp[a - c])
+                }
+            }
+        }
+
+        // NeetCode's exact return logic:
+        // If dp[amount] is still "infinity", the amount is unreachable → return -1.
+        return dp[amount] != amount + 1 ? dp[amount] : -1
+    }
+}

--- a/SwiftChallenges/NeetCode/DynamicProgramming/CoinChange.swift
+++ b/SwiftChallenges/NeetCode/DynamicProgramming/CoinChange.swift
@@ -3,7 +3,7 @@
 //  SwiftChallenges
 //
 //  Created by KyleLearnedThis on 7/5/26.
-//
+//  https://leetcode.com/problems/coin-change
 
 // ============================================================
 // V1 — Bottom-up DP (Claude)

--- a/SwiftChallengesTests/NeetCode/Backtracking/NeetWordSearchTest.swift
+++ b/SwiftChallengesTests/NeetCode/Backtracking/NeetWordSearchTest.swift
@@ -11,7 +11,7 @@ class NeetWordSearchTest: XCTestCase {
 
     private let sut = NeetWordSearch()
 
-    private func verify(_ board: [[Character]], _ word: String, file: StaticString = #file, line: UInt = #line) -> Bool {
+    private func verify(_ board: [[Character]], _ word: String, file: StaticString = #filePath, line: UInt = #line) -> Bool {
         sut.exist(board, word)
     }
 

--- a/SwiftChallengesTests/NeetCode/DynamicProgramming/CoinChangeTest.swift
+++ b/SwiftChallengesTests/NeetCode/DynamicProgramming/CoinChangeTest.swift
@@ -1,0 +1,105 @@
+//
+//  CoinChangeTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/5/26.
+//
+
+import XCTest
+
+class CoinChangeTest: XCTestCase {
+
+    private let sut = CoinChange()
+
+    private func verifyV1(_ coins: [Int], _ amount: Int, expected: Int, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.coinChange(coins, amount), expected, file: file, line: line)
+    }
+
+    private func verifyV2(_ coins: [Int], _ amount: Int, expected: Int, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.coinChangeV2(coins, amount), expected, file: file, line: line)
+    }
+
+    // MARK: - V1 Base cases
+
+    func testV1ZeroAmount() {
+        verifyV1([1, 5, 10], 0, expected: 0)
+    }
+
+    func testV1SingleCoinExact() {
+        verifyV1([5], 5, expected: 1)
+    }
+
+    func testV1SingleCoinImpossible() {
+        verifyV1([5], 3, expected: -1)
+    }
+
+    // MARK: - V1 LeetCode examples
+
+    func testV1Example1() {
+        verifyV1([1, 5, 11], 15, expected: 3)
+    }
+
+    func testV1Example2() {
+        verifyV1([2], 3, expected: -1)
+    }
+
+    func testV1Example3() {
+        verifyV1([1], 0, expected: 0)
+    }
+
+    // MARK: - V1 Edge cases
+
+    func testV1LargeAmount() {
+        verifyV1([1, 5, 10, 25], 100, expected: 4)
+    }
+
+    func testV1NoExactChange() {
+        verifyV1([3, 7], 5, expected: -1)
+    }
+
+    func testV1MultipleDenominations() {
+        verifyV1([1, 2, 5], 11, expected: 3)
+    }
+
+    // MARK: - V2 Base cases
+
+    func testV2ZeroAmount() {
+        verifyV2([1, 5, 10], 0, expected: 0)
+    }
+
+    func testV2SingleCoinExact() {
+        verifyV2([5], 5, expected: 1)
+    }
+
+    func testV2SingleCoinImpossible() {
+        verifyV2([5], 3, expected: -1)
+    }
+
+    // MARK: - V2 LeetCode examples
+
+    func testV2Example1() {
+        verifyV2([1, 5, 11], 15, expected: 3)
+    }
+
+    func testV2Example2() {
+        verifyV2([2], 3, expected: -1)
+    }
+
+    func testV2Example3() {
+        verifyV2([1], 0, expected: 0)
+    }
+
+    // MARK: - V2 Edge cases
+
+    func testV2LargeAmount() {
+        verifyV2([1, 5, 10, 25], 100, expected: 4)
+    }
+
+    func testV2NoExactChange() {
+        verifyV2([3, 7], 5, expected: -1)
+    }
+
+    func testV2MultipleDenominations() {
+        verifyV2([1, 2, 5], 11, expected: 3)
+    }
+}

--- a/SwiftChallengesTests/NeetCode/Graphs/PacificAtlanticWaterFlowTest.swift
+++ b/SwiftChallengesTests/NeetCode/Graphs/PacificAtlanticWaterFlowTest.swift
@@ -20,7 +20,7 @@ class PacificAtlanticWaterFlowTest: XCTestCase {
         cells.sorted { $0[0] != $1[0] ? $0[0] < $1[0] : $0[1] < $1[1] }
     }
 
-    private func verify(_ heights: [[Int]], expected: [[Int]], file: StaticString = #file, line: UInt = #line) {
+    private func verify(_ heights: [[Int]], expected: [[Int]], file: StaticString = #filePath, line: UInt = #line) {
         for solve in solutions {
             XCTAssertEqual(sorted(solve(heights)), expected, file: (file), line: line)
         }

--- a/SwiftChallengesTests/NeetCode/TopologicalSort/AlienDictionaryTest.swift
+++ b/SwiftChallengesTests/NeetCode/TopologicalSort/AlienDictionaryTest.swift
@@ -27,7 +27,7 @@ class AlienDictionaryTest: XCTestCase {
         return true
     }
 
-    private func verify(_ words: [String], file: StaticString = #file, line: UInt = #line) -> String {
+    private func verify(_ words: [String], file: StaticString = #filePath, line: UInt = #line) -> String {
         sut.alienOrder(words)
     }
 


### PR DESCRIPTION
## Summary
- Adds `CoinChange.swift` with two bottom-up DP implementations (V1 readable style, V2 NeetCode compact style)
- Adds `CoinChangeTest.swift` with full test coverage for both implementations (base cases, LeetCode examples, edge cases)
- Registers both files in `project.pbxproj`

## Test plan
- [x] Cmd+B in Xcode — build is clean
- [x] Run `CoinChangeTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)