### PR TITLE
Add LongestIncreasingSubsequence, CoinChange rename, small fixes

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -761,6 +761,9 @@
 		35E1227AF475C356BC55155F /* CoinChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298AD4B33D6C05B7105E04A2 /* CoinChange.swift */; };
 		B8D9E334EFF34FC2B3049B61 /* CoinChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298AD4B33D6C05B7105E04A2 /* CoinChange.swift */; };
 		08F6CB7CF0E2CAE0A8A9C64C /* CoinChangeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C36F49BD6B9284D49C16C4E /* CoinChangeTest.swift */; };
+		F6419997AE3FCC9E8F6858BA /* LongestIncreasingSubsequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A1B78A9748CD9BDC9DCFF3 /* LongestIncreasingSubsequence.swift */; };
+		8B19B5E82C83555552E0CF2C /* LongestIncreasingSubsequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A1B78A9748CD9BDC9DCFF3 /* LongestIncreasingSubsequence.swift */; };
+		5E7AAD5388C167C96C256A42 /* LongestIncreasingSubsequenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22173E0B1E6779B1D7EE7D4B /* LongestIncreasingSubsequenceTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1270,6 +1273,8 @@
 		8911F1C9E7590CC01E1C576C /* HouseRobberTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseRobberTest.swift; sourceTree = "<group>"; };
 		298AD4B33D6C05B7105E04A2 /* CoinChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinChange.swift; sourceTree = "<group>"; };
 		5C36F49BD6B9284D49C16C4E /* CoinChangeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinChangeTest.swift; sourceTree = "<group>"; };
+		A4A1B78A9748CD9BDC9DCFF3 /* LongestIncreasingSubsequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestIncreasingSubsequence.swift; sourceTree = "<group>"; };
+		22173E0B1E6779B1D7EE7D4B /* LongestIncreasingSubsequenceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestIncreasingSubsequenceTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2683,6 +2688,7 @@
 				88823EBAC9077A39CB52BEFB /* ClimbingStairs.swift */,
 				0EB140F0D32D3658B4853ECA /* HouseRobber.swift */,
 				298AD4B33D6C05B7105E04A2 /* CoinChange.swift */,
+				A4A1B78A9748CD9BDC9DCFF3 /* LongestIncreasingSubsequence.swift */,
 			);
 			path = DynamicProgramming;
 			sourceTree = "<group>";
@@ -2693,6 +2699,7 @@
 				6D0AECFF09758AB9CDB36558 /* ClimbingStairsTest.swift */,
 				8911F1C9E7590CC01E1C576C /* HouseRobberTest.swift */,
 				5C36F49BD6B9284D49C16C4E /* CoinChangeTest.swift */,
+				22173E0B1E6779B1D7EE7D4B /* LongestIncreasingSubsequenceTest.swift */,
 			);
 			path = DynamicProgramming;
 			sourceTree = "<group>";
@@ -2891,6 +2898,7 @@
 				0C66A612E055B4B20E783C4D /* ClimbingStairs.swift in Sources */,
 				B27EC53E03379A14E1FF7108 /* HouseRobber.swift in Sources */,
 				35E1227AF475C356BC55155F /* CoinChange.swift in Sources */,
+				F6419997AE3FCC9E8F6858BA /* LongestIncreasingSubsequence.swift in Sources */,
 				DEC3D823287EB74100EB14F8 /* ReshapeMatrix.swift in Sources */,
 				DECCF07A27FCFEE3007BA99C /* RestoreString.swift in Sources */,
 				DECCEFD227FCFB76007BA99C /* EratosthenesSieve.swift in Sources */,
@@ -3273,6 +3281,8 @@
 				62F2FA0C66FCFE4006860F31 /* HouseRobberTest.swift in Sources */,
 				B8D9E334EFF34FC2B3049B61 /* CoinChange.swift in Sources */,
 				08F6CB7CF0E2CAE0A8A9C64C /* CoinChangeTest.swift in Sources */,
+				8B19B5E82C83555552E0CF2C /* LongestIncreasingSubsequence.swift in Sources */,
+				5E7AAD5388C167C96C256A42 /* LongestIncreasingSubsequenceTest.swift in Sources */,
 				DE4B8F6C289BACAD00DF9D4C /* ArraySimiliar.swift in Sources */,
 				DE15998D28B773F00081E2BE /* ArrayPermutations.swift in Sources */,
 				DEDB4946283CDD7F00B2238B /* CountValleys.swift in Sources */,

--- a/SwiftChallenges/NeetCode/DynamicProgramming/CoinChange.swift
+++ b/SwiftChallenges/NeetCode/DynamicProgramming/CoinChange.swift
@@ -42,7 +42,7 @@
 // KEY LINES (exactly what NeetCode codes in Python, now in Swift):
 //   var dp = Array(repeating: amount + 1, count: amount + 1)
 //   dp[0] = 0
-//   for a in 1...amount { for c in coins { if c <= a { dp[a] = min(dp[a], 1 + dp[a - c]) } } }
+//   for remaining in 1...amount { for coin in coins { if coin <= remaining { dp[remaining] = min(dp[remaining], 1 + dp[remaining - coin]) } } }
 //   return dp[amount] != amount + 1 ? dp[amount] : -1
 //
 // TIME:  O(amount × coins.count)
@@ -98,18 +98,18 @@ class CoinChange {
         guard amount > 0 else { return 0 }
 
         // Outer loop: solve every sub-amount from 1 up to the target.
-        // Think of `a` as "how much do I still need to make?"
-        for a in 1...amount {
+        // Think of `remaining` as "how much do I still need to make?"
+        for remaining in 1...amount {
 
             // Inner loop: try every coin denomination.
-            for c in coins {
+            for coin in coins {
 
                 // Only valid if this coin doesn't overshoot the current amount.
-                if c <= a {
-                    // "If I use coin c once, I already solved dp[a - c].
-                    //  So the total cost is 1 + dp[a - c]."
+                if coin <= remaining {
+                    // "If I use this coin once, I already solved dp[remaining - coin].
+                    //  So the total cost is 1 + dp[remaining - coin]."
                     // Keep the minimum across all coin choices.
-                    dp[a] = min(dp[a], 1 + dp[a - c])
+                    dp[remaining] = min(dp[remaining], 1 + dp[remaining - coin])
                 }
             }
         }

--- a/SwiftChallenges/NeetCode/DynamicProgramming/HouseRobber.swift
+++ b/SwiftChallenges/NeetCode/DynamicProgramming/HouseRobber.swift
@@ -3,7 +3,7 @@
 //  SwiftChallenges
 //
 //  Created by KyleLearnedThis on 7/5/26.
-//
+//  https://leetcode.com/problems/house-robber/
 
 class HouseRobber {
 

--- a/SwiftChallenges/NeetCode/DynamicProgramming/LongestIncreasingSubsequence.swift
+++ b/SwiftChallenges/NeetCode/DynamicProgramming/LongestIncreasingSubsequence.swift
@@ -1,0 +1,27 @@
+//
+//  LongestIncreasingSubsequence.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/7/26.
+//  https://leetcode.com/problems/longest-increasing-subsequence/
+
+// TIME:  O(n^2)
+// SPACE: O(n)
+
+class LongestIncreasingSubsequence {
+
+    func lengthOfLIS(_ nums: [Int]) -> Int {
+        // Initialize every index to 1 because it's a subsequence of just itself
+        var cache = Array<Int>(repeating: 1, count: nums.count)
+        // Travel from the last index and build up cache
+        for i in (0..<nums.count).reversed() {
+            for j in i+1..<nums.count {
+                // if nums[i] -> nums[j] is increasing order
+                if nums[j] > nums[i] {
+                    cache[i] = max(cache[i], 1 + cache[j])
+                }
+            }
+        }
+        return cache.max() ?? 0
+    }
+}

--- a/SwiftChallengesTests/NeetCode/DynamicProgramming/ClimbingStairsTest.swift
+++ b/SwiftChallengesTests/NeetCode/DynamicProgramming/ClimbingStairsTest.swift
@@ -11,7 +11,7 @@ class ClimbingStairsTest: XCTestCase {
 
     private let sut = ClimbingStairs()
 
-    private func verify(_ n: Int, _ expected: Int, file: StaticString = #file, line: UInt = #line) {
+    private func verify(_ n: Int, _ expected: Int, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(sut.climbStairs(n), expected, file: file, line: line)
     }
 

--- a/SwiftChallengesTests/NeetCode/DynamicProgramming/LongestIncreasingSubsequenceTest.swift
+++ b/SwiftChallengesTests/NeetCode/DynamicProgramming/LongestIncreasingSubsequenceTest.swift
@@ -1,0 +1,72 @@
+//
+//  LongestIncreasingSubsequenceTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/7/26.
+//
+
+import XCTest
+
+class LongestIncreasingSubsequenceTest: XCTestCase {
+
+    private let sut = LongestIncreasingSubsequence()
+
+    private func verify(
+        _ nums: [Int],
+        _ expected: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(sut.lengthOfLIS(nums), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testEmptyArray() {
+        verify([], 0)
+    }
+
+    func testSingleElement() {
+        verify([5], 1)
+    }
+
+    func testTwoElementsIncreasing() {
+        verify([1, 2], 2)
+    }
+
+    func testTwoElementsDecreasing() {
+        verify([2, 1], 1)
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify([10, 9, 2, 5, 3, 7, 101, 18], 4)
+    }
+
+    func testExample2() {
+        verify([0, 1, 0, 3, 2, 3], 4)
+    }
+
+    func testExample3() {
+        verify([7, 7, 7, 7, 7, 7, 7], 1)
+    }
+
+    // MARK: - Edge cases
+
+    func testStrictlyDecreasing() {
+        verify([5, 4, 3, 2, 1], 1)
+    }
+
+    func testStrictlyIncreasing() {
+        verify([1, 2, 3, 4, 5], 5)
+    }
+
+    func testNegativeNumbers() {
+        verify([-2, -1, -3, 0, -4], 3)
+    }
+
+    func testWithDuplicates() {
+        verify([4, 10, 4, 3, 8, 9], 3)
+    }
+}


### PR DESCRIPTION
## Summary
- Add LongestIncreasingSubsequence solution and unit tests
- Rename ambiguous `a`/`c` variables to `remaining`/`coin` in CoinChange V2 for readability
- Add LeetCode link to HouseRobber header comment
- Use `#filePath` instead of `#file` in ClimbingStairsTest

## Test plan
- [x] Unit tests pass for LongestIncreasingSubsequence
- [x] Existing CoinChange tests still pass after rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)