### PR TITLE
Add BurstBalloons solution and unit tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5898D391568420DC7FE64DE7 /* BurstBalloons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5615ADB62C6B329D093AC2 /* BurstBalloons.swift */; };
+		07F5EC01CE40CA048B2FAF10 /* BurstBalloons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5615ADB62C6B329D093AC2 /* BurstBalloons.swift */; };
+		06502013C1CB0BAE6849C707 /* BurstBalloonsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9692FE13B217DA1C6DCD260E /* BurstBalloonsTest.swift */; };
 		7B14CEAD741A462F8DE1E064 /* TreeNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076B40BB3E2B478B981B501C /* TreeNode.swift */; };
 		93B48BDB12AD4876A8414F70 /* TreePrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2000075220BA4121BAC5C8F4 /* TreePrinter.swift */; };
 		C7FBECB1581E4A01B10333B5 /* TreePrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2000075220BA4121BAC5C8F4 /* TreePrinter.swift */; };
@@ -780,6 +783,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4B5615ADB62C6B329D093AC2 /* BurstBalloons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurstBalloons.swift; sourceTree = "<group>"; };
+		9692FE13B217DA1C6DCD260E /* BurstBalloonsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurstBalloonsTest.swift; sourceTree = "<group>"; };
 		076B40BB3E2B478B981B501C /* TreeNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeNode.swift; sourceTree = "<group>"; };
 		2000075220BA4121BAC5C8F4 /* TreePrinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreePrinter.swift; sourceTree = "<group>"; };
 		DE15996C28B4306C0081E2BE /* IPChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPChecker.swift; sourceTree = "<group>"; };
@@ -2695,6 +2700,7 @@
 				298AD4B33D6C05B7105E04A2 /* CoinChange.swift */,
 				A4A1B78A9748CD9BDC9DCFF3 /* LongestIncreasingSubsequence.swift */,
 				29BE0A6DEF0C358CE88B3654 /* EditDistance.swift */,
+				4B5615ADB62C6B329D093AC2 /* BurstBalloons.swift */,
 			);
 			path = DynamicProgramming;
 			sourceTree = "<group>";
@@ -2707,6 +2713,7 @@
 				5C36F49BD6B9284D49C16C4E /* CoinChangeTest.swift */,
 				22173E0B1E6779B1D7EE7D4B /* LongestIncreasingSubsequenceTest.swift */,
 				BAE92AE1DA756CA00918E0CB /* EditDistanceTest.swift */,
+				9692FE13B217DA1C6DCD260E /* BurstBalloonsTest.swift */,
 			);
 			path = DynamicProgramming;
 			sourceTree = "<group>";
@@ -2828,6 +2835,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5898D391568420DC7FE64DE7 /* BurstBalloons.swift in Sources */,
 				FB5E4FB32FA450BB0014F0DF /* MedianTwoSortedArrays.swift in Sources */,
 				DE604CAD2808E1F700C62CE6 /* RevenueMilestones.swift in Sources */,
 				DECCEE8127FCF8B4007BA99C /* SingleNumber.swift in Sources */,
@@ -3097,6 +3105,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07F5EC01CE40CA048B2FAF10 /* BurstBalloons.swift in Sources */,
+				06502013C1CB0BAE6849C707 /* BurstBalloonsTest.swift in Sources */,
 				DECCEF5D27FCF9C1007BA99C /* RankTransformArrayTest.swift in Sources */,
 				DECCEEB327FCF8E9007BA99C /* RansomNotes.swift in Sources */,
 				DE221EEB2819490100CAE40D /* SimpleLinkedListTest.swift in Sources */,

--- a/SwiftChallenges/Lab/classics/AirportRoute.swift
+++ b/SwiftChallenges/Lab/classics/AirportRoute.swift
@@ -7,17 +7,14 @@ class AirportRoute {
         var dict = [String:String]()
         for i in input {
             let x = i.components(separatedBy: "-")
-            let key = x[0]
-            let value = x[1]
-            print("====== key: \(key) value: \(value)")
-            dict[key] = value
+            guard x.count == 2 else { continue }
+            dict[x[0]] = x[1]
         }
-        
+
         var start: String = getStartingPoint(dict: dict)
-        print("Start: \(start)")
         result.append(start)
         for _ in 1...input.count {
-            let value = dict[start]!
+            guard let value = dict[start] else { break }
             result.append(value)
             start = value
         }

--- a/SwiftChallenges/NeetCode/DynamicProgramming/BurstBalloons.swift
+++ b/SwiftChallenges/NeetCode/DynamicProgramming/BurstBalloons.swift
@@ -1,0 +1,100 @@
+//
+//  BurstBalloons.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/8/26.
+//  https://leetcode.com/problems/burst-balloons/
+
+/// Time complexity: O(n^3), where n is `nums.count`. We fill an (n+2) x (n+2)
+/// `dp` table indexed by (left, right) boundary pairs, and for each pair we try
+/// every `k` strictly between them as the "last balloon burst" in that range —
+/// O(n^2) pairs times O(n) choices of `k`.
+/// Space complexity: O(n^2) for the `dp` table (plus the padded O(n) balloons array).
+///
+/// `maxCoins` (bottom-up) vs `maxCoinsV2` (top-down DFS + memo):
+/// - DFS + memo is the easier one to write and memorize: it's a near-literal
+///   transcription of the recurrence — "pick the last balloon burst in this
+///   range, recurse on the two halves, cache it" — with no separate mental
+///   step for iteration order.
+/// - Bottom-up requires reasoning about iteration order (shorter windows
+///   before longer ones, so `length` must be the outer loop), which is an
+///   extra thing to get right under pressure and a common source of bugs
+///   (off-by-one ranges, wrong loop nesting).
+/// - The base case is trivial in DFS (`left + 1 == right` -> 0 coins), while
+///   bottom-up encodes it implicitly by leaving those cells at their default 0.
+/// - Rule of thumb for interval DP (burst balloons, matrix chain
+///   multiplication, palindrome partitioning, etc.): write the DFS + memo
+///   version first; convert to bottom-up later only if you need to shave off
+///   recursion-stack overhead or iterative code is required.
+class BurstBalloons {
+
+    func maxCoins(_ nums: [Int]) -> Int {
+        if nums.isEmpty { return 0 }
+
+        // Pad with virtual balloons of value 1 on both ends so every burst,
+        // including the first and last real balloon, has well-defined neighbors.
+        var balloons = [1]
+        balloons.append(contentsOf: nums)
+        balloons.append(1)
+        let n = balloons.count
+
+        // dp[left][right] = max coins obtainable by bursting every balloon
+        // strictly between indices `left` and `right`, leaving `left` and
+        // `right` themselves intact as the eventual neighbors.
+        var dp = Array(repeating: Array(repeating: 0, count: n), count: n)
+
+        // Build up by increasing window length so dp[left][k] and dp[k][right]
+        // are already computed when we need them for dp[left][right].
+        for length in 2..<n {
+            for left in 0..<(n - length) {
+                let right = left + length
+                // Try every balloon `k` in (left, right) as the LAST one burst
+                // in this window: once it's the last, `left` and `right` are
+                // its neighbors, so bursting it yields balloons[left] * balloons[k] * balloons[right].
+                for k in (left + 1)..<right {
+                    let coins = dp[left][k] + balloons[left] * balloons[k] * balloons[right] + dp[k][right]
+                    dp[left][right] = max(dp[left][right], coins)
+                }
+            }
+        }
+
+        return dp[0][n - 1]
+    }
+
+    /// Time complexity: O(n^3) — same as `maxCoins`, but built top-down instead
+    /// of bottom-up. Each of the O(n^2) (left, right) pairs is solved once
+    /// (thanks to `memo`) by trying O(n) choices of `k` as the last balloon burst.
+    /// Space complexity: O(n^2) for `memo` plus O(n) recursion depth on the call stack.
+    func maxCoinsV2(_ nums: [Int]) -> Int {
+        if nums.isEmpty { return 0 }
+
+        // Pad with virtual balloons of value 1 on both ends, same as maxCoins.
+        var balloons = [1]
+        balloons.append(contentsOf: nums)
+        balloons.append(1)
+        let n = balloons.count
+
+        // memo[left][right] caches the max coins for bursting everything
+        // strictly between `left` and `right`. -1 means "not yet computed".
+        var memo = Array(repeating: Array(repeating: -1, count: n), count: n)
+
+        func dfs(_ left: Int, _ right: Int) -> Int {
+            // No balloons left to burst in this window.
+            if left + 1 == right { return 0 }
+            if memo[left][right] != -1 { return memo[left][right] }
+
+            var best = 0
+            // Pick `k` as the last balloon burst in (left, right); its
+            // neighbors at that moment are `left` and `right`.
+            for k in (left + 1)..<right {
+                let coins = dfs(left, k) + balloons[left] * balloons[k] * balloons[right] + dfs(k, right)
+                best = max(best, coins)
+            }
+
+            memo[left][right] = best
+            return best
+        }
+
+        return dfs(0, n - 1)
+    }
+}

--- a/SwiftChallengesTests/NeetCode/DynamicProgramming/BurstBalloonsTest.swift
+++ b/SwiftChallengesTests/NeetCode/DynamicProgramming/BurstBalloonsTest.swift
@@ -1,0 +1,60 @@
+//
+//  BurstBalloonsTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/8/26.
+//
+
+import XCTest
+
+class BurstBalloonsTest: XCTestCase {
+
+    private let sut = BurstBalloons()
+
+    private func verify(_ nums: [Int], expected: Int, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.maxCoins(nums), expected, file: file, line: line)
+        XCTAssertEqual(sut.maxCoinsV2(nums), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testEmptyArray() {
+        verify([], expected: 0)
+    }
+
+    func testSingleBalloon() {
+        verify([5], expected: 5)
+    }
+
+    func testTwoBalloons() {
+        verify([1, 1], expected: 2)
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify([3, 1, 5, 8], expected: 167)
+    }
+
+    func testExample2() {
+        verify([1, 5], expected: 10)
+    }
+
+    // MARK: - Edge cases
+
+    func testAllOnes() {
+        verify([1, 1, 1], expected: 3)
+    }
+
+    func testDuplicateValues() {
+        verify([3, 3], expected: 12)
+    }
+
+    func testZeroValuedBalloon() {
+        verify([0], expected: 0)
+    }
+
+    func testZeroInMiddle() {
+        verify([3, 0, 5], expected: 20)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BurstBalloons.maxCoins` (bottom-up interval DP, O(n^3) time / O(n^2) space)
- Add `BurstBalloons.maxCoinsV2` (top-down memoized DFS, same complexity, easier to derive from the recurrence)
- Class-level doc comment compares the two approaches and gives a rule of thumb for interval DP problems
- Add `BurstBalloonsTest` covering base cases, LeetCode examples, and edge cases (both implementations verified against every case)

## Test plan
- [x] `xcodebuild test -only-testing:SwiftChallengesTests/BurstBalloonsTest` passes (9/9)