### PR TITLE
Add DailyTemperatures monotonic stack scaffold and solution

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A93DC3E0411299F517F576DF /* HappyNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */; };
+		6F858E13E99D31FA38904C26 /* HappyNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */; };
+		828DFD4EA258F20AAC39E92D /* HappyNumberTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */; };
+		D05C6B5094E764EF0D252EF0 /* SumOfTwoIntegers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */; };
+		B8252DE478FC822991463D36 /* SumOfTwoIntegers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */; };
+		D6BC46EE8546E1EE36F947ED /* SumOfTwoIntegersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49B7D460C451C4948AC1A42 /* SumOfTwoIntegersTest.swift */; };
 		06502013C1CB0BAE6849C707 /* BurstBalloonsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9692FE13B217DA1C6DCD260E /* BurstBalloonsTest.swift */; };
 		0740FC6E87029AD5DAB42D15 /* CourseSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C486AA15563A4867D9BC9F85 /* CourseSchedule.swift */; };
 		07CD87575D13C1B18210086E /* NumberOf1Bits.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0080A6351AF7C22CB04E73E /* NumberOf1Bits.swift */; };
@@ -792,6 +798,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumOfTwoIntegers.swift; sourceTree = "<group>"; };
+		A49B7D460C451C4948AC1A42 /* SumOfTwoIntegersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumOfTwoIntegersTest.swift; sourceTree = "<group>"; };
+		34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HappyNumber.swift; sourceTree = "<group>"; };
+		28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HappyNumberTest.swift; sourceTree = "<group>"; };
 		03A13D9047AF1BCEE4A199BA /* NQueens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NQueens.swift; sourceTree = "<group>"; };
 		06ECA24A5B5B8EA3B921D438 /* NeetWordSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetWordSearch.swift; sourceTree = "<group>"; };
 		076B40BB3E2B478B981B501C /* TreeNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeNode.swift; sourceTree = "<group>"; };
@@ -2386,12 +2396,21 @@
 			path = DynamicProgramming;
 			sourceTree = "<group>";
 		};
+		88E1ED6CCA605FB6BCF29FCB /* MathGeometry */ = {
+			isa = PBXGroup;
+			children = (
+				34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */,
+			);
+			path = MathGeometry;
+			sourceTree = "<group>";
+		};
 		E5DF15F53210DD3B58956E02 /* BitManipulation */ = {
 			isa = PBXGroup;
 			children = (
 				F0080A6351AF7C22CB04E73E /* NumberOf1Bits.swift */,
 				2ED15ACAB6612B488D6A93E6 /* NeetSingleNumber.swift */,
 				959B652ECE4BD2AE4E3E603B /* ReverseBits.swift */,
+				44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */,
 			);
 			path = BitManipulation;
 			sourceTree = "<group>";
@@ -2409,12 +2428,21 @@
 			path = DynamicProgramming;
 			sourceTree = "<group>";
 		};
+		FDF73F5B1508FFFA75DDE559 /* MathGeometry */ = {
+			isa = PBXGroup;
+			children = (
+				28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */,
+			);
+			path = MathGeometry;
+			sourceTree = "<group>";
+		};
 		F881B0A08F6663EF18143409 /* BitManipulation */ = {
 			isa = PBXGroup;
 			children = (
 				2309C7D68FC1ECBBF6EDFDF0 /* NumberOf1BitsTest.swift */,
 				134ED134D2B1A6C1DDC5364E /* NeetSingleNumberTest.swift */,
 				4670FF829920033EC115F6C6 /* ReverseBitsTest.swift */,
+				A49B7D460C451C4948AC1A42 /* SumOfTwoIntegersTest.swift */,
 			);
 			path = BitManipulation;
 			sourceTree = "<group>";
@@ -2616,6 +2644,7 @@
 				6B236F157C5761123F4BD54E /* TopologicalSort */,
 				F14FBA533AFBD7FC2ABF689B /* DynamicProgramming */,
 				F881B0A08F6663EF18143409 /* BitManipulation */,
+				FDF73F5B1508FFFA75DDE559 /* MathGeometry */,
 			);
 			path = NeetCode;
 			sourceTree = "<group>";
@@ -2640,6 +2669,7 @@
 				0600CCD466D5A4D18C8E4199 /* TopologicalSort */,
 				E04F4ADDB0E9152694B9EC57 /* DynamicProgramming */,
 				E5DF15F53210DD3B58956E02 /* BitManipulation */,
+				88E1ED6CCA605FB6BCF29FCB /* MathGeometry */,
 			);
 			path = NeetCode;
 			sourceTree = "<group>";
@@ -2872,6 +2902,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A93DC3E0411299F517F576DF /* HappyNumber.swift in Sources */,
+				D05C6B5094E764EF0D252EF0 /* SumOfTwoIntegers.swift in Sources */,
 				07CD87575D13C1B18210086E /* NumberOf1Bits.swift in Sources */,
 				17D02B3B691F78670A1BE634 /* NeetSingleNumber.swift in Sources */,
 				6F44147C2D17DDA424D143BE /* ReverseBits.swift in Sources */,
@@ -3145,6 +3177,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F858E13E99D31FA38904C26 /* HappyNumber.swift in Sources */,
+				828DFD4EA258F20AAC39E92D /* HappyNumberTest.swift in Sources */,
+				B8252DE478FC822991463D36 /* SumOfTwoIntegers.swift in Sources */,
+				D6BC46EE8546E1EE36F947ED /* SumOfTwoIntegersTest.swift in Sources */,
 				C31F71391B5242A26795EC98 /* NumberOf1Bits.swift in Sources */,
 				6466FBC5326207274F224534 /* NumberOf1BitsTest.swift in Sources */,
 				67B93FA433D046FF4C1FDEE0 /* NeetSingleNumber.swift in Sources */,

--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -699,6 +699,9 @@
 		FB2C5DC02FD527D2009550A1 /* NextGreaterElementI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */; };
 		FB2C5DC12FD527D2009550A1 /* NextGreaterElementI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */; };
 		FB2C5DC42FD5281B009550A1 /* NextGreaterElementITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DC32FD5281B009550A1 /* NextGreaterElementITest.swift */; };
+		0C9C9E3A9C51A6AD9D6AA475 /* NeetDailyTemperatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7DE7FEF43C2E560D7826FA /* NeetDailyTemperatures.swift */; };
+		178DCF1689FB6F84F61A2522 /* NeetDailyTemperatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7DE7FEF43C2E560D7826FA /* NeetDailyTemperatures.swift */; };
+		E9D3C6020A68359350EC95AE /* NeetDailyTemperaturesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17AA66B2463A2D62D960414 /* NeetDailyTemperaturesTest.swift */; };
 		FB2C5DC72FD53283009550A1 /* ReverseLinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DC62FD53283009550A1 /* ReverseLinkedList.swift */; };
 		FB2C5DC82FD53283009550A1 /* ReverseLinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DC62FD53283009550A1 /* ReverseLinkedList.swift */; };
 		FB2C5DCB2FD5335D009550A1 /* ReverseLinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DCA2FD5335D009550A1 /* ReverseLinkedListTest.swift */; };
@@ -1253,6 +1256,8 @@
 		FB2C5DBC2FD4D141009550A1 /* LargestRectangleHistogramTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargestRectangleHistogramTest.swift; sourceTree = "<group>"; };
 		FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextGreaterElementI.swift; sourceTree = "<group>"; };
 		FB2C5DC32FD5281B009550A1 /* NextGreaterElementITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextGreaterElementITest.swift; sourceTree = "<group>"; };
+		4B7DE7FEF43C2E560D7826FA /* NeetDailyTemperatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetDailyTemperatures.swift; sourceTree = "<group>"; };
+		E17AA66B2463A2D62D960414 /* NeetDailyTemperaturesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetDailyTemperaturesTest.swift; sourceTree = "<group>"; };
 		FB2C5DC62FD53283009550A1 /* ReverseLinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseLinkedList.swift; sourceTree = "<group>"; };
 		FB2C5DCA2FD5335D009550A1 /* ReverseLinkedListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseLinkedListTest.swift; sourceTree = "<group>"; };
 		FB2C5DCC2FD537C2009550A1 /* MergeTwoSortedLists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeTwoSortedLists.swift; sourceTree = "<group>"; };
@@ -2517,6 +2522,7 @@
 			isa = PBXGroup;
 			children = (
 				FB2C5DBF2FD527D2009550A1 /* NextGreaterElementI.swift */,
+				4B7DE7FEF43C2E560D7826FA /* NeetDailyTemperatures.swift */,
 			);
 			path = MonotonicStack;
 			sourceTree = "<group>";
@@ -2525,6 +2531,7 @@
 			isa = PBXGroup;
 			children = (
 				FB2C5DC32FD5281B009550A1 /* NextGreaterElementITest.swift */,
+				E17AA66B2463A2D62D960414 /* NeetDailyTemperaturesTest.swift */,
 			);
 			path = MonotonicStack;
 			sourceTree = "<group>";
@@ -3012,6 +3019,7 @@
 				DECCEE7B27FCF8B4007BA99C /* MoveZeroesInArray.swift in Sources */,
 				FB49A3B42F9F1C9F0013680A /* LinkedListCycle2.swift in Sources */,
 				FB2C5DC12FD527D2009550A1 /* NextGreaterElementI.swift in Sources */,
+				0C9C9E3A9C51A6AD9D6AA475 /* NeetDailyTemperatures.swift in Sources */,
 				DEA5C1E3282B8676004AE296 /* DivisibleSumPairs.swift in Sources */,
 				DECCEFCB27FCFB4C007BA99C /* PriorityQueue.swift in Sources */,
 				FB49A38E2F9DF3950013680A /* ContainerWithMostWater.swift in Sources */,
@@ -3286,6 +3294,7 @@
 				DECCEF6527FCF9C1007BA99C /* MoneyInLeetcodeBankTest.swift in Sources */,
 				DE2E0F8D280EBE11006D06FA /* WrongAnswerOnlyTest.swift in Sources */,
 				FB2C5DC02FD527D2009550A1 /* NextGreaterElementI.swift in Sources */,
+				178DCF1689FB6F84F61A2522 /* NeetDailyTemperatures.swift in Sources */,
 				DEDB4952283DA30E00B2238B /* HurdleRaceTest.swift in Sources */,
 				FB2C5DBA2FD4CE49009550A1 /* LargestRectangleHistogram.swift in Sources */,
 				FB1543C12FDF543F00697F86 /* NeetWordLadderTest.swift in Sources */,
@@ -3611,6 +3620,7 @@
 				DE4B8F50289A62D700DF9D4C /* CanBeIncreasingArray.swift in Sources */,
 				DEE62549283B4186003EC784 /* BetweenTwoSetsTest.swift in Sources */,
 				FB2C5DC42FD5281B009550A1 /* NextGreaterElementITest.swift in Sources */,
+				E9D3C6020A68359350EC95AE /* NeetDailyTemperaturesTest.swift in Sources */,
 				DEC3D838287F917900EB14F8 /* StickCut.swift in Sources */,
 				FB1543BF2FDF540F00697F86 /* NeetWordLadder.swift in Sources */,
 				DE1CA2F927FED812001D8BD1 /* NumberPlusMinus.swift in Sources */,

--- a/SwiftChallenges/Lab/numbers/DailyTemperatures.swift
+++ b/SwiftChallenges/Lab/numbers/DailyTemperatures.swift
@@ -3,7 +3,7 @@
 //  SwiftCodes
 //
 //  Copyright © 2019 kylelearnedthis. All rights reserved.
-//
+//  https://leetcode.com/problems/daily-temperatures/
 
 import Foundation
 
@@ -34,4 +34,5 @@ class DailyTemperatures {
         }
         return 0
     }
+    
 }

--- a/SwiftChallenges/NeetCode/BitManipulation/SumOfTwoIntegers.swift
+++ b/SwiftChallenges/NeetCode/BitManipulation/SumOfTwoIntegers.swift
@@ -1,0 +1,24 @@
+//
+//  SumOfTwoIntegers.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/12/26.
+//  https://leetcode.com/problems/sum-of-two-integers/
+
+class SumOfTwoIntegers {
+
+    func getSum(_ a: Int, _ b: Int) -> Int {
+        var a = a, b = b
+        // Repeat until there's no carry left to add in.
+        while b != 0 {
+            // XOR adds each bit pair without propagating a carry (1+1 -> 0, dropping the carry).
+            let sum = a ^ b
+            // AND finds every position that generated a carry; shift it left to line up
+            // with the next bit position, matching how carries work in grade-school addition.
+            let carry = (a & b) << 1
+            a = sum
+            b = carry
+        }
+        return a
+    }
+}

--- a/SwiftChallenges/NeetCode/MathGeometry/HappyNumber.swift
+++ b/SwiftChallenges/NeetCode/MathGeometry/HappyNumber.swift
@@ -1,0 +1,24 @@
+//
+//  HappyNumber.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/12/26.
+//  https://leetcode.com/problems/happy-number/
+
+class HappyNumber {
+
+    func isHappy(_ n: Int) -> Bool {
+        var seen = Set<Int>()
+        var current = n
+        while current != 1 {
+            let temp = Array(String(current))
+            let digits = temp.map { $0.wholeNumberValue! * $0.wholeNumberValue! }
+            current = digits.reduce(0, +)
+            if seen.contains(current) {
+                return false
+            }
+            seen.insert(current)
+        }
+        return true
+    }
+}

--- a/SwiftChallenges/NeetCode/MonotonicStack/NeetDailyTemperatures.swift
+++ b/SwiftChallenges/NeetCode/MonotonicStack/NeetDailyTemperatures.swift
@@ -1,0 +1,13 @@
+//
+//  NeetDailyTemperatures.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/12/26.
+//
+
+class NeetDailyTemperatures {
+
+    func dailyTemperatures(_ temperatures: [Int]) -> [Int] {
+        return []
+    }
+}

--- a/SwiftChallenges/NeetCode/MonotonicStack/NeetDailyTemperatures.swift
+++ b/SwiftChallenges/NeetCode/MonotonicStack/NeetDailyTemperatures.swift
@@ -3,11 +3,32 @@
 //  SwiftChallenges
 //
 //  Created by KyleLearnedThis on 7/12/26.
-//
+//  https://leetcode.com/problems/daily-temperatures/
+//  Time O(N), Space O(N)
 
 class NeetDailyTemperatures {
 
     func dailyTemperatures(_ temperatures: [Int]) -> [Int] {
-        return []
+        // Default 0 = "no warmer day ahead" for every day.
+        var result = Array(repeating: 0, count: temperatures.count)
+
+        // Monotonic stack of days still waiting for a warmer day.
+        // Invariant: temperatures at these indices are strictly decreasing
+        // from bottom to top, so the top is always the coldest so far.
+        var stack: [(temperature: Int, day: Int)] = []
+
+        for (currentDay, currentTemp) in temperatures.enumerated() {
+            // Today is warmer than the days on top of the stack, so today
+            // is the answer for each of them. Pop and record the wait.
+            while let coldest = stack.last, currentTemp > coldest.temperature {
+                stack.removeLast()
+                result[coldest.day] = currentDay - coldest.day
+            }
+            // Today now waits for its own warmer day.
+            stack.append((currentTemp, currentDay))
+        }
+
+        // Any days left on the stack never found a warmer day, so they keep 0.
+        return result
     }
 }

--- a/SwiftChallengesTests/NeetCode/BitManipulation/SumOfTwoIntegersTest.swift
+++ b/SwiftChallengesTests/NeetCode/BitManipulation/SumOfTwoIntegersTest.swift
@@ -1,0 +1,55 @@
+//
+//  SumOfTwoIntegersTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/12/26.
+//
+
+import XCTest
+
+class SumOfTwoIntegersTest: XCTestCase {
+
+    private let sut = SumOfTwoIntegers()
+
+    private func verify(_ a: Int, _ b: Int, _ expected: Int, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.getSum(a, b), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testZeroPlusZero() {
+        verify(0, 0, 0)
+    }
+
+    func testZeroPlusPositive() {
+        verify(0, 5, 5)
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify(1, 2, 3)
+    }
+
+    func testExample2() {
+        verify(2, 3, 5)
+    }
+
+    // MARK: - Edge cases
+
+    func testNegativeNumbers() {
+        verify(-1, -2, -3)
+    }
+
+    func testPositiveAndNegative() {
+        verify(-5, 5, 0)
+    }
+
+    func testUpperBoundaryValues() {
+        verify(1000, 1000, 2000)
+    }
+
+    func testLowerBoundaryValues() {
+        verify(-1000, -1000, -2000)
+    }
+}

--- a/SwiftChallengesTests/NeetCode/MathGeometry/HappyNumberTest.swift
+++ b/SwiftChallengesTests/NeetCode/MathGeometry/HappyNumberTest.swift
@@ -1,0 +1,51 @@
+//
+//  HappyNumberTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/12/26.
+//
+
+import XCTest
+
+class HappyNumberTest: XCTestCase {
+
+    private let sut = HappyNumber()
+
+    private func verify(_ n: Int, _ expected: Bool, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.isHappy(n), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testOneIsHappy() {
+        verify(1, true)
+    }
+
+    func testSevenIsHappy() {
+        verify(7, true)
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify(19, true)
+    }
+
+    func testExample2() {
+        verify(2, false)
+    }
+
+    // MARK: - Edge cases
+
+    func testFourIsUnhappy() {
+        verify(4, false)
+    }
+
+    func testLargeUnhappyNumber() {
+        verify(11, false)
+    }
+
+    func testLargeHappyNumber() {
+        verify(100, true)
+    }
+}

--- a/SwiftChallengesTests/NeetCode/MonotonicStack/NeetDailyTemperaturesTest.swift
+++ b/SwiftChallengesTests/NeetCode/MonotonicStack/NeetDailyTemperaturesTest.swift
@@ -1,0 +1,51 @@
+//
+//  NeetDailyTemperaturesTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/12/26.
+//
+
+import XCTest
+
+class NeetDailyTemperaturesTest: XCTestCase {
+
+    private let sut = NeetDailyTemperatures()
+
+    private func verify(_ temperatures: [Int], _ expected: [Int], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.dailyTemperatures(temperatures), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testEmpty() {
+        verify([], [])
+    }
+
+    func testSingleElement() {
+        verify([30], [0])
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify([73, 74, 75, 71, 69, 72, 76, 73], [1, 1, 4, 2, 1, 1, 0, 0])
+    }
+
+    func testExample2() {
+        verify([30, 40, 50, 60], [1, 1, 1, 0])
+    }
+
+    func testExample3() {
+        verify([30, 60, 90], [1, 1, 0])
+    }
+
+    // MARK: - Edge cases
+
+    func testAllDescending() {
+        verify([90, 80, 70], [0, 0, 0])
+    }
+
+    func testAllEqual() {
+        verify([50, 50, 50], [0, 0, 0])
+    }
+}


### PR DESCRIPTION
## Summary
- Scaffold `NeetDailyTemperatures` (solution + XCTest) under `NeetCode/MonotonicStack` via the `/leetcode` skill
- Implement the O(n) monotonic-stack solution for LeetCode 739. Daily Temperatures
- Add the LeetCode problem URL to the existing `Lab/numbers/DailyTemperatures.swift` header

## Notes
- Solution uses a monotonic (strictly decreasing) stack of `(temperature, day)` pairs; each day is pushed and popped at most once → O(n) time, O(n) space.
- Named tuple elements, optional binding, and study comments added for readability.

## Test plan
- [x] Open in Xcode, Cmd+B builds clean
- [x] Run `NeetDailyTemperaturesTest` — base cases, 3 LeetCode examples, and edge cases (all-descending, all-equal) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)