### PR TITLE
Add RotateImage layer-rotation solution with tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		A93DC3E0411299F517F576DF /* HappyNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */; };
 		6F858E13E99D31FA38904C26 /* HappyNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */; };
 		828DFD4EA258F20AAC39E92D /* HappyNumberTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */; };
+		ED6417E669BD944EA70887F4 /* RotateImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3847D0D325153FA3319751 /* RotateImage.swift */; };
+		3CA6DC0BA0B3F918E68D1251 /* RotateImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3847D0D325153FA3319751 /* RotateImage.swift */; };
+		49D388E20D9CB8B3C0B3070F /* RotateImageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05160229E3F38A7C40DDB71 /* RotateImageTest.swift */; };
 		D05C6B5094E764EF0D252EF0 /* SumOfTwoIntegers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */; };
 		B8252DE478FC822991463D36 /* SumOfTwoIntegers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */; };
 		D6BC46EE8546E1EE36F947ED /* SumOfTwoIntegersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49B7D460C451C4948AC1A42 /* SumOfTwoIntegersTest.swift */; };
@@ -808,6 +811,8 @@
 		A49B7D460C451C4948AC1A42 /* SumOfTwoIntegersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumOfTwoIntegersTest.swift; sourceTree = "<group>"; };
 		34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HappyNumber.swift; sourceTree = "<group>"; };
 		28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HappyNumberTest.swift; sourceTree = "<group>"; };
+		2A3847D0D325153FA3319751 /* RotateImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotateImage.swift; sourceTree = "<group>"; };
+		F05160229E3F38A7C40DDB71 /* RotateImageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotateImageTest.swift; sourceTree = "<group>"; };
 		03A13D9047AF1BCEE4A199BA /* NQueens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NQueens.swift; sourceTree = "<group>"; };
 		06ECA24A5B5B8EA3B921D438 /* NeetWordSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetWordSearch.swift; sourceTree = "<group>"; };
 		076B40BB3E2B478B981B501C /* TreeNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeNode.swift; sourceTree = "<group>"; };
@@ -2410,6 +2415,7 @@
 			isa = PBXGroup;
 			children = (
 				34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */,
+				2A3847D0D325153FA3319751 /* RotateImage.swift */,
 			);
 			path = MathGeometry;
 			sourceTree = "<group>";
@@ -2442,6 +2448,7 @@
 			isa = PBXGroup;
 			children = (
 				28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */,
+				F05160229E3F38A7C40DDB71 /* RotateImageTest.swift */,
 			);
 			path = MathGeometry;
 			sourceTree = "<group>";
@@ -2917,6 +2924,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A93DC3E0411299F517F576DF /* HappyNumber.swift in Sources */,
+				ED6417E669BD944EA70887F4 /* RotateImage.swift in Sources */,
 				D05C6B5094E764EF0D252EF0 /* SumOfTwoIntegers.swift in Sources */,
 				07CD87575D13C1B18210086E /* NumberOf1Bits.swift in Sources */,
 				17D02B3B691F78670A1BE634 /* NeetSingleNumber.swift in Sources */,
@@ -3195,6 +3203,8 @@
 			files = (
 				6F858E13E99D31FA38904C26 /* HappyNumber.swift in Sources */,
 				828DFD4EA258F20AAC39E92D /* HappyNumberTest.swift in Sources */,
+				3CA6DC0BA0B3F918E68D1251 /* RotateImage.swift in Sources */,
+				49D388E20D9CB8B3C0B3070F /* RotateImageTest.swift in Sources */,
 				B8252DE478FC822991463D36 /* SumOfTwoIntegers.swift in Sources */,
 				D6BC46EE8546E1EE36F947ED /* SumOfTwoIntegersTest.swift in Sources */,
 				C31F71391B5242A26795EC98 /* NumberOf1Bits.swift in Sources */,

--- a/SwiftChallenges/NeetCode/MathGeometry/RotateImage.swift
+++ b/SwiftChallenges/NeetCode/MathGeometry/RotateImage.swift
@@ -1,0 +1,44 @@
+//
+//  RotateImage.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/12/26.
+//  https://leetcode.com/problems/rotate-image/
+
+// Rotate an N×N matrix 90° clockwise, in place.
+//
+// Time:  O(n²) — every one of the n² cells is moved exactly once.
+// Space: O(1) — swaps happen in place; only a single temp value is held.
+class RotateImage {
+
+    func rotate(_ matrix: inout [[Int]]) {
+        // Peel the matrix in concentric square layers from the outside in.
+        // `left`/`right` are the column (and, since it's square, the row)
+        // bounds of the current layer. When they meet, the center is done.
+        var left = 0
+        var right = matrix.count - 1
+
+        while left < right {
+            let top = left       // top row index of this layer
+            let bottom = right   // bottom row index of this layer
+
+            // Walk the top edge left→right. Each `i` picks the four corners
+            // of one inscribed "diamond" and spins them 90° clockwise.
+            // right - left is the number of elements to rotate in this layer.
+            for i in 0 ..< right - left {
+                // Save the top corner so it isn't overwritten, then pull each
+                // slot from the one 90° counter-clockwise of it:
+                // top ← left ← bottom ← right ← (saved top).
+                let topLeft = matrix[top][left + i]
+                matrix[top][left + i] = matrix[bottom - i][left]      // ↖ ← ↙
+                matrix[bottom - i][left] = matrix[bottom][right - i]  // ↙ ← ↘
+                matrix[bottom][right - i] = matrix[top + i][right]    // ↘ ← ↗
+                matrix[top + i][right] = topLeft                      // ↗ ← ↖
+            }
+
+            // Shrink to the next inner layer.
+            right = right - 1
+            left = left + 1
+        }
+    }
+}

--- a/SwiftChallengesTests/NeetCode/MathGeometry/RotateImageTest.swift
+++ b/SwiftChallengesTests/NeetCode/MathGeometry/RotateImageTest.swift
@@ -1,0 +1,61 @@
+//
+//  RotateImageTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/12/26.
+//
+
+import XCTest
+
+class RotateImageTest: XCTestCase {
+
+    private let sut = RotateImage()
+
+    private func verify(_ input: [[Int]], _ expected: [[Int]], file: StaticString = #filePath, line: UInt = #line) {
+        var matrix = input
+        sut.rotate(&matrix)
+        XCTAssertEqual(matrix, expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testSingleElement() {
+        verify([[1]], [[1]])
+    }
+
+    func testTwoByTwo() {
+        verify([[1, 2], [3, 4]], [[3, 1], [4, 2]])
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify(
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            [[7, 4, 1], [8, 5, 2], [9, 6, 3]]
+        )
+    }
+
+    func testExample2() {
+        verify(
+            [[5, 1, 9, 11], [2, 4, 8, 10], [13, 3, 6, 7], [15, 14, 12, 16]],
+            [[15, 13, 2, 5], [14, 3, 4, 1], [12, 6, 8, 9], [16, 7, 10, 11]]
+        )
+    }
+
+    // MARK: - Edge cases
+
+    func testNegativeValues() {
+        verify(
+            [[-1, -2], [-3, -4]],
+            [[-3, -1], [-4, -2]]
+        )
+    }
+
+    func testDuplicateValues() {
+        verify(
+            [[1, 1], [1, 1]],
+            [[1, 1], [1, 1]]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add **48. Rotate Image** solution using the concentric-layer in-place rotation (O(n²) time, O(1) space).
- Study comments throughout, with time/space complexity noted above the class.
- Full XCTest suite: base cases, both LeetCode examples, and edge cases (negatives, duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)