### PR TITLE
Add SpiralMatrix boundary-peeling solution with study comments and tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		828DFD4EA258F20AAC39E92D /* HappyNumberTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */; };
 		ED6417E669BD944EA70887F4 /* RotateImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3847D0D325153FA3319751 /* RotateImage.swift */; };
 		3CA6DC0BA0B3F918E68D1251 /* RotateImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3847D0D325153FA3319751 /* RotateImage.swift */; };
+		2F477566B1C4A4940A9EFDA8 /* SpiralMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F191A657B61E944C4CA54 /* SpiralMatrix.swift */; };
+		8F543616F38F2DEE616687E9 /* SpiralMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C6F191A657B61E944C4CA54 /* SpiralMatrix.swift */; };
+		4769408FD3436E1564CB1DC3 /* SpiralMatrixTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE785E3ECF0D8A74DDB268B /* SpiralMatrixTest.swift */; };
 		49D388E20D9CB8B3C0B3070F /* RotateImageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05160229E3F38A7C40DDB71 /* RotateImageTest.swift */; };
 		D05C6B5094E764EF0D252EF0 /* SumOfTwoIntegers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */; };
 		B8252DE478FC822991463D36 /* SumOfTwoIntegers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */; };
@@ -812,6 +815,8 @@
 		34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HappyNumber.swift; sourceTree = "<group>"; };
 		28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HappyNumberTest.swift; sourceTree = "<group>"; };
 		2A3847D0D325153FA3319751 /* RotateImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotateImage.swift; sourceTree = "<group>"; };
+		9C6F191A657B61E944C4CA54 /* SpiralMatrix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpiralMatrix.swift; sourceTree = "<group>"; };
+		DEE785E3ECF0D8A74DDB268B /* SpiralMatrixTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpiralMatrixTest.swift; sourceTree = "<group>"; };
 		F05160229E3F38A7C40DDB71 /* RotateImageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotateImageTest.swift; sourceTree = "<group>"; };
 		03A13D9047AF1BCEE4A199BA /* NQueens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NQueens.swift; sourceTree = "<group>"; };
 		06ECA24A5B5B8EA3B921D438 /* NeetWordSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeetWordSearch.swift; sourceTree = "<group>"; };
@@ -2416,6 +2421,7 @@
 			children = (
 				34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */,
 				2A3847D0D325153FA3319751 /* RotateImage.swift */,
+				9C6F191A657B61E944C4CA54 /* SpiralMatrix.swift */,
 			);
 			path = MathGeometry;
 			sourceTree = "<group>";
@@ -2449,6 +2455,7 @@
 			children = (
 				28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */,
 				F05160229E3F38A7C40DDB71 /* RotateImageTest.swift */,
+				DEE785E3ECF0D8A74DDB268B /* SpiralMatrixTest.swift */,
 			);
 			path = MathGeometry;
 			sourceTree = "<group>";
@@ -2925,6 +2932,7 @@
 			files = (
 				A93DC3E0411299F517F576DF /* HappyNumber.swift in Sources */,
 				ED6417E669BD944EA70887F4 /* RotateImage.swift in Sources */,
+				2F477566B1C4A4940A9EFDA8 /* SpiralMatrix.swift in Sources */,
 				D05C6B5094E764EF0D252EF0 /* SumOfTwoIntegers.swift in Sources */,
 				07CD87575D13C1B18210086E /* NumberOf1Bits.swift in Sources */,
 				17D02B3B691F78670A1BE634 /* NeetSingleNumber.swift in Sources */,
@@ -3204,6 +3212,8 @@
 				6F858E13E99D31FA38904C26 /* HappyNumber.swift in Sources */,
 				828DFD4EA258F20AAC39E92D /* HappyNumberTest.swift in Sources */,
 				3CA6DC0BA0B3F918E68D1251 /* RotateImage.swift in Sources */,
+				8F543616F38F2DEE616687E9 /* SpiralMatrix.swift in Sources */,
+				4769408FD3436E1564CB1DC3 /* SpiralMatrixTest.swift in Sources */,
 				49D388E20D9CB8B3C0B3070F /* RotateImageTest.swift in Sources */,
 				B8252DE478FC822991463D36 /* SumOfTwoIntegers.swift in Sources */,
 				D6BC46EE8546E1EE36F947ED /* SumOfTwoIntegersTest.swift in Sources */,

--- a/SwiftChallenges/NeetCode/MathGeometry/SpiralMatrix.swift
+++ b/SwiftChallenges/NeetCode/MathGeometry/SpiralMatrix.swift
@@ -1,0 +1,61 @@
+//
+//  SpiralMatrix.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/13/26.
+//  https://leetcode.com/problems/spiral-matrix/
+
+// Read an m×n matrix in spiral order (right → down → left → up), peeling
+// one boundary layer per lap.
+//
+// Time:  O(m·n) — every cell is visited and appended exactly once.
+// Space: O(1) extra — only the four boundary indices (output array aside).
+class SpiralMatrix {
+
+    func spiralOrder(_ matrix: [[Int]]) -> [Int] {
+        var result = [Int]()
+        // Four walls of the not-yet-visited region. They close inward:
+        // l/r are the left/right columns, t/d the top/down (bottom) rows.
+        var l = 0
+        var r = matrix[0].count - 1
+        var t = 0
+        var d = matrix.count - 1
+
+        // Loop while the window still encloses at least one cell.
+        while l <= r && t <= d {
+            // Top row, left → right. Then that row is consumed, so drop it.
+            for i in l...r {
+                result.append(matrix[t][i])
+            }
+            t = t + 1
+
+            // Right column, top → bottom (from the new top t, not t+1).
+            // Guard: after t++ the window may already be empty vertically;
+            // t...d would be an inverted range and Swift traps on that.
+            if t > d { break }
+            for i in t...d {
+                result.append(matrix[i][r])
+            }
+            r = r - 1
+
+            // Bottom row, right → left. Guard against a now-empty window
+            // horizontally (single-row layers finish here).
+            if l > r { break }
+            for i in (l...r).reversed() {
+                result.append(matrix[d][i])
+            }
+            d = d - 1
+
+            // Left column, bottom → top. Guard again: single-column layers
+            // finish here, so t...d could be inverted.
+            if t > d { break }
+            for i in (t...d).reversed() {
+                result.append(matrix[i][l])
+            }
+
+            l = l + 1
+        }
+
+        return result
+    }
+}

--- a/SwiftChallengesTests/NeetCode/MathGeometry/SpiralMatrixTest.swift
+++ b/SwiftChallengesTests/NeetCode/MathGeometry/SpiralMatrixTest.swift
@@ -1,0 +1,67 @@
+//
+//  SpiralMatrixTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/13/26.
+//
+
+import XCTest
+
+class SpiralMatrixTest: XCTestCase {
+
+    private let sut = SpiralMatrix()
+
+    private func verify(_ matrix: [[Int]], _ expected: [Int], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.spiralOrder(matrix), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testSingleElement() {
+        verify([[1]], [1])
+    }
+
+    func testSingleRow() {
+        verify([[1, 2, 3, 4]], [1, 2, 3, 4])
+    }
+
+    func testSingleColumn() {
+        verify([[1], [2], [3], [4]], [1, 2, 3, 4])
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        verify(
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            [1, 2, 3, 6, 9, 8, 7, 4, 5]
+        )
+    }
+
+    func testExample2() {
+        verify(
+            [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+            [1, 2, 3, 4, 8, 12, 11, 10, 9, 5, 6, 7]
+        )
+    }
+
+    // MARK: - Edge cases
+
+    func testTwoByTwo() {
+        verify([[1, 2], [3, 4]], [1, 2, 4, 3])
+    }
+
+    func testTallRectangle() {
+        verify(
+            [[1, 2], [3, 4], [5, 6]],
+            [1, 2, 4, 6, 5, 3]
+        )
+    }
+
+    func testNegativeValues() {
+        verify(
+            [[-1, -2], [-3, -4]],
+            [-1, -2, -4, -3]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SpiralMatrix.spiralOrder`, reading an m×n matrix in spiral order by peeling one boundary layer per lap (right → down → left → up).
- Four boundary indices (`l`, `r`, `t`, `d`) close inward; break guards prevent inverted ranges on single-row/single-column layers.
- O(m·n) time, O(1) extra space (output array aside).
- Registers the solution and test files into the Xcode project.

## Test plan
- Added `SpiralMatrixTest` covering the spiral traversal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)