### PR TITLE
Add ReverseNodesInKGroup group-reversal solution with study comments and tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -729,6 +729,9 @@
 		FB2C5DE52FD61C5D009550A1 /* ReverseLinkedListII.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DE42FD61C5D009550A1 /* ReverseLinkedListII.swift */; };
 		FB2C5DE62FD61C5D009550A1 /* ReverseLinkedListII.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DE42FD61C5D009550A1 /* ReverseLinkedListII.swift */; };
 		FB2C5DEA2FD61D2E009550A1 /* ReverseLinkedListIITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DE92FD61D2E009550A1 /* ReverseLinkedListIITest.swift */; };
+		242A78949A87E0D53709D0B7 /* ReverseNodesInKGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0A782E15E23D3091DB6AB /* ReverseNodesInKGroup.swift */; };
+		0C43E5807B6B869B799826D5 /* ReverseNodesInKGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0A782E15E23D3091DB6AB /* ReverseNodesInKGroup.swift */; };
+		C78A8FD9AC6AD4406F7714EB /* ReverseNodesInKGroupTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57D0DF33BD598BF7E5BFDD3 /* ReverseNodesInKGroupTest.swift */; };
 		FB2C5DEE2FD7BBF9009550A1 /* MaximumDepthBinaryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DED2FD7BBF9009550A1 /* MaximumDepthBinaryTree.swift */; };
 		FB2C5DEF2FD7BBF9009550A1 /* MaximumDepthBinaryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DED2FD7BBF9009550A1 /* MaximumDepthBinaryTree.swift */; };
 		FB2C5DF12FD7BE07009550A1 /* MaximumDepthBinaryTreeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C5DF02FD7BE07009550A1 /* MaximumDepthBinaryTreeTest.swift */; };
@@ -1288,6 +1291,8 @@
 		FB2C5DDC2FD5506C009550A1 /* MergeKSortedListsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeKSortedListsTest.swift; sourceTree = "<group>"; };
 		FB2C5DE42FD61C5D009550A1 /* ReverseLinkedListII.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseLinkedListII.swift; sourceTree = "<group>"; };
 		FB2C5DE92FD61D2E009550A1 /* ReverseLinkedListIITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseLinkedListIITest.swift; sourceTree = "<group>"; };
+		A1C0A782E15E23D3091DB6AB /* ReverseNodesInKGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseNodesInKGroup.swift; sourceTree = "<group>"; };
+		C57D0DF33BD598BF7E5BFDD3 /* ReverseNodesInKGroupTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseNodesInKGroupTest.swift; sourceTree = "<group>"; };
 		FB2C5DED2FD7BBF9009550A1 /* MaximumDepthBinaryTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaximumDepthBinaryTree.swift; sourceTree = "<group>"; };
 		FB2C5DF02FD7BE07009550A1 /* MaximumDepthBinaryTreeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaximumDepthBinaryTreeTest.swift; sourceTree = "<group>"; };
 		FB2C5DF32FD7C442009550A1 /* InvertBinaryTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InvertBinaryTree.swift; path = SwiftChallenges/NeetCode/Trees/InvertBinaryTree.swift; sourceTree = SOURCE_ROOT; };
@@ -2590,6 +2595,7 @@
 			isa = PBXGroup;
 			children = (
 				FB2C5DE42FD61C5D009550A1 /* ReverseLinkedListII.swift */,
+				A1C0A782E15E23D3091DB6AB /* ReverseNodesInKGroup.swift */,
 			);
 			path = ReverseLinkedList;
 			sourceTree = "<group>";
@@ -2598,6 +2604,7 @@
 			isa = PBXGroup;
 			children = (
 				FB2C5DE92FD61D2E009550A1 /* ReverseLinkedListIITest.swift */,
+				C57D0DF33BD598BF7E5BFDD3 /* ReverseNodesInKGroupTest.swift */,
 			);
 			path = ReverseLinkedList;
 			sourceTree = "<group>";
@@ -3010,6 +3017,7 @@
 				FB49A3AB2F9F1B640013680A /* GroupAnagrams.swift in Sources */,
 				FB2C5DD82FD54FE7009550A1 /* MergeKSortedLists.swift in Sources */,
 				FB2C5DE52FD61C5D009550A1 /* ReverseLinkedListII.swift in Sources */,
+				242A78949A87E0D53709D0B7 /* ReverseNodesInKGroup.swift in Sources */,
 				DEA5C1DB282B7E83004AE296 /* PersonalScoresCount.swift in Sources */,
 				FB1543C52FDFB21E00697F86 /* NeetSubsets.swift in Sources */,
 				42D58F7AD3D74ED4B6C3A75A /* NeetPermutations.swift in Sources */,
@@ -3443,6 +3451,8 @@
 				DECCEF9A27FCF9C1007BA99C /* CountNegativeMatrixTest.swift in Sources */,
 				DECCEEB127FCF8E3007BA99C /* StockTrading.swift in Sources */,
 				FB2C5DE62FD61C5D009550A1 /* ReverseLinkedListII.swift in Sources */,
+				0C43E5807B6B869B799826D5 /* ReverseNodesInKGroup.swift in Sources */,
+				C78A8FD9AC6AD4406F7714EB /* ReverseNodesInKGroupTest.swift in Sources */,
 				DECCF04D27FCFE49007BA99C /* BSTInversion.swift in Sources */,
 				DECCEF9627FCF9C1007BA99C /* StockTradingTest.swift in Sources */,
 				DECCEEE527FCF97C007BA99C /* MappingTransform.swift in Sources */,

--- a/SwiftChallenges/NeetCode/ReverseLinkedList/ReverseNodesInKGroup.swift
+++ b/SwiftChallenges/NeetCode/ReverseLinkedList/ReverseNodesInKGroup.swift
@@ -1,0 +1,69 @@
+//
+//  ReverseNodesInKGroup.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/19/26.
+//
+
+class ReverseNodesInKGroup {
+
+    // Reverse every consecutive block of k nodes; leave a trailing block
+    // shorter than k untouched. Work group-by-group, reversing each in place.
+    //
+    // Key pointers per group:
+    //   groupPrev  - the node just BEFORE the current group (starts at dummy)
+    //   groupEnd   - the LAST node of the current group (nil => fewer than k left)
+    //   groupNext  - the first node AFTER the group (groupEnd.next), our stop marker
+    func reverseKGroup(_ head: ListNode?, _ k: Int) -> ListNode? {
+        // dummy sits before head so the first group has a "prev" to reconnect to,
+        // and dummy.next always points at the final head of the list.
+        let dummy = ListNode(0, head)
+        var groupPrev: ListNode? = dummy
+
+        while true {
+            // Find the group's end (the kth node from groupPrev). If it's nil the
+            // remaining tail is shorter than k, so we stop and leave it as-is.
+            let groupEnd = getKth(groupPrev, k)
+            if groupEnd == nil {
+                break
+            }
+            let groupNext = groupEnd?.next
+
+            // Standard in-place reversal of the group. Seeding prev with groupNext
+            // (instead of nil) reconnects the group's new tail to the rest of the
+            // list automatically. Stop by identity when cur reaches groupNext.
+            var prev: ListNode? = groupNext
+            var cur: ListNode? = groupPrev?.next
+
+            while cur !== groupNext {
+                let temp = cur?.next
+                cur?.next = prev
+                prev = cur
+                cur = temp
+            }
+
+            // Before: groupPrev -> [first ... groupEnd] -> groupNext
+            // groupPrev.next is still the OLD first node, which is now the group's
+            // tail — and it's exactly the "prev" the next group will hang off of.
+            // Point groupPrev at groupEnd (the new head), then advance to that old-first
+            // node for the next iteration.
+            let newGroupPrev = groupPrev?.next
+            groupPrev?.next = groupEnd
+            groupPrev = newGroupPrev
+        }
+
+        return dummy.next
+    }
+
+    // Walk k steps forward from cur. Returns the kth node, or nil if the list
+    // ends before k steps (i.e. fewer than k nodes remain).
+    func getKth(_ cur: ListNode?, _ k: Int) -> ListNode? {
+        var cur = cur
+        var k = k
+        while cur != nil, k > 0 {
+            cur = cur?.next
+            k = k - 1
+        }
+        return cur
+    }
+}

--- a/SwiftChallengesTests/NeetCode/ReverseLinkedList/ReverseNodesInKGroupTest.swift
+++ b/SwiftChallengesTests/NeetCode/ReverseLinkedList/ReverseNodesInKGroupTest.swift
@@ -1,0 +1,87 @@
+//
+//  ReverseNodesInKGroupTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/19/26.
+//
+
+import XCTest
+
+class ReverseNodesInKGroupTest: XCTestCase {
+
+    private let sut = ReverseNodesInKGroup()
+
+    private func makeList(_ vals: [Int]) -> ListNode? {
+        guard !vals.isEmpty else { return nil }
+        let head = ListNode(vals[0])
+        var current = head
+        for val in vals.dropFirst() {
+            let node = ListNode(val)
+            current.next = node
+            current = node
+        }
+        return head
+    }
+
+    private func toArray(_ head: ListNode?) -> [Int] {
+        var result: [Int] = []
+        var current = head
+        while let node = current {
+            result.append(node.val)
+            current = node.next
+        }
+        return result
+    }
+
+    private func verify(_ vals: [Int], _ k: Int, _ expected: [Int], file: StaticString = #filePath, line: UInt = #line) {
+        let result = sut.reverseKGroup(makeList(vals), k)
+        XCTAssertEqual(toArray(result), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testEmptyList() {
+        verify([], 1, [])
+    }
+
+    func testSingleElement() {
+        verify([1], 1, [1])
+    }
+
+    func testKEqualsOne() {
+        // k=1 leaves the list unchanged
+        verify([1, 2, 3, 4, 5], 1, [1, 2, 3, 4, 5])
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        // [1,2,3,4,5], k=2 -> [2,1,4,3,5]
+        verify([1, 2, 3, 4, 5], 2, [2, 1, 4, 3, 5])
+    }
+
+    func testExample2() {
+        // [1,2,3,4,5], k=3 -> [3,2,1,4,5]
+        verify([1, 2, 3, 4, 5], 3, [3, 2, 1, 4, 5])
+    }
+
+    // MARK: - Edge cases
+
+    func testLengthDivisibleByK() {
+        verify([1, 2, 3, 4], 2, [2, 1, 4, 3])
+    }
+
+    func testKEqualsLength() {
+        verify([1, 2, 3, 4, 5], 5, [5, 4, 3, 2, 1])
+    }
+
+    func testKGreaterThanLength() {
+        // No complete group of size k, list stays unchanged
+        verify([1, 2, 3], 4, [1, 2, 3])
+    }
+
+    func testLeftoverTailUnreversed() {
+        // [1,2,3,4,5,6,7], k=3 -> [3,2,1,6,5,4,7]
+        verify([1, 2, 3, 4, 5, 6, 7], 3, [3, 2, 1, 6, 5, 4, 7])
+    }
+}


### PR DESCRIPTION
## Summary
- Solves LeetCode #25 (Reverse Nodes in k-Group) with the dummy-node + `groupPrev`/`groupEnd` approach, reversing each block of k nodes in place and leaving any trailing block shorter than k untouched.
- Reverses each group by seeding `prev` with `groupNext` so the reversed block auto-reconnects to the rest of the list; stops by reference identity (`!==`) since `ListNode` isn't `Equatable`.
- Adds study comments explaining the key pointers and the relink step.

## Tests
- `ReverseNodesInKGroupTest` covers the two LeetCode examples (k=2, k=3), base cases (empty, single, k=1), and edge cases (length divisible by k, k=length, k>length, leftover tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)