### PR TITLE
Add MeetingRooms interval-overlap solution with study comments and tests

### DIFF
--- a/SwiftChallenges.xcodeproj/project.pbxproj
+++ b/SwiftChallenges.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D210FAC58C1CE2EE1EBD2BF /* MeetingRooms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E680500CC8660A986ECD51 /* MeetingRooms.swift */; };
+		7687B5BFB423028C522653D6 /* MeetingRooms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E680500CC8660A986ECD51 /* MeetingRooms.swift */; };
+		F28D7EC478ED1CD6AB21208A /* MeetingRoomsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF82E04745704EFD44ED9245 /* MeetingRoomsTest.swift */; };
 		A93DC3E0411299F517F576DF /* HappyNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */; };
 		6F858E13E99D31FA38904C26 /* HappyNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */; };
 		828DFD4EA258F20AAC39E92D /* HappyNumberTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E9E305D0A33152385CD9F3 /* HappyNumberTest.swift */; };
@@ -816,6 +819,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		20E680500CC8660A986ECD51 /* MeetingRooms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingRooms.swift; sourceTree = "<group>"; };
+		DF82E04745704EFD44ED9245 /* MeetingRoomsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingRoomsTest.swift; sourceTree = "<group>"; };
 		44FA636537735481449A54B0 /* SumOfTwoIntegers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumOfTwoIntegers.swift; sourceTree = "<group>"; };
 		A49B7D460C451C4948AC1A42 /* SumOfTwoIntegersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumOfTwoIntegersTest.swift; sourceTree = "<group>"; };
 		34B6A98466E4AE704A8FBD49 /* HappyNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HappyNumber.swift; sourceTree = "<group>"; };
@@ -2667,6 +2672,22 @@
 			path = TwoPointers;
 			sourceTree = "<group>";
 		};
+		19ECFFC2BD62F4916624CB7A /* Intervals */ = {
+			isa = PBXGroup;
+			children = (
+				20E680500CC8660A986ECD51 /* MeetingRooms.swift */,
+			);
+			path = Intervals;
+			sourceTree = "<group>";
+		};
+		0436099BC1C8F159D07C9CAD /* Intervals */ = {
+			isa = PBXGroup;
+			children = (
+				DF82E04745704EFD44ED9245 /* MeetingRoomsTest.swift */,
+			);
+			path = Intervals;
+			sourceTree = "<group>";
+		};
 		FB49A3972F9F0FE70013680A /* NeetCode */ = {
 			isa = PBXGroup;
 			children = (
@@ -2687,6 +2708,7 @@
 				F14FBA533AFBD7FC2ABF689B /* DynamicProgramming */,
 				F881B0A08F6663EF18143409 /* BitManipulation */,
 				FDF73F5B1508FFFA75DDE559 /* MathGeometry */,
+				0436099BC1C8F159D07C9CAD /* Intervals */,
 			);
 			path = NeetCode;
 			sourceTree = "<group>";
@@ -2712,6 +2734,7 @@
 				E04F4ADDB0E9152694B9EC57 /* DynamicProgramming */,
 				E5DF15F53210DD3B58956E02 /* BitManipulation */,
 				88E1ED6CCA605FB6BCF29FCB /* MathGeometry */,
+				19ECFFC2BD62F4916624CB7A /* Intervals */,
 			);
 			path = NeetCode;
 			sourceTree = "<group>";
@@ -2945,6 +2968,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A93DC3E0411299F517F576DF /* HappyNumber.swift in Sources */,
+				0D210FAC58C1CE2EE1EBD2BF /* MeetingRooms.swift in Sources */,
 				ED6417E669BD944EA70887F4 /* RotateImage.swift in Sources */,
 				2F477566B1C4A4940A9EFDA8 /* SpiralMatrix.swift in Sources */,
 				29FE8E812BA2C0C9339CFD88 /* PowXN.swift in Sources */,
@@ -3226,6 +3250,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				6F858E13E99D31FA38904C26 /* HappyNumber.swift in Sources */,
+				7687B5BFB423028C522653D6 /* MeetingRooms.swift in Sources */,
+				F28D7EC478ED1CD6AB21208A /* MeetingRoomsTest.swift in Sources */,
 				828DFD4EA258F20AAC39E92D /* HappyNumberTest.swift in Sources */,
 				3CA6DC0BA0B3F918E68D1251 /* RotateImage.swift in Sources */,
 				8F543616F38F2DEE616687E9 /* SpiralMatrix.swift in Sources */,

--- a/SwiftChallenges/NeetCode/Intervals/MeetingRooms.swift
+++ b/SwiftChallenges/NeetCode/Intervals/MeetingRooms.swift
@@ -1,0 +1,39 @@
+//
+//  MeetingRooms.swift
+//  SwiftChallenges
+//
+//  Created by KyleLearnedThis on 7/20/26.
+//
+
+// 252. Meeting Rooms
+//
+// Given an array of meeting time intervals where intervals[i] = [start_i, end_i],
+// determine if a person could attend all meetings.
+//
+// Example 1:
+//   Input:  [[0, 30], [5, 10], [15, 20]]
+//   Output: false   ([0,30] overlaps [5,10] and [15,20])
+//
+// Example 2:
+//   Input:  [[7, 10], [2, 4]]
+//   Output: true    (no overlaps)
+//
+// Note: meetings that only touch at an endpoint (one ends when the next begins,
+// e.g. [1,5] and [5,10]) do NOT count as overlapping.
+class MeetingRooms {
+
+    func canAttendMeetings(_ intervals: [[Int]]) -> Bool {
+        if intervals.isEmpty { return true }
+        let sorted = intervals.sorted { $0[0] < $1[0] }
+        for i in 0..<sorted.count - 1 {
+            let first = sorted[i]
+            let second = sorted[i+1]
+            
+            // first's end time > second's start time
+            if first[1] > second[0] {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/SwiftChallengesTests/NeetCode/Intervals/MeetingRoomsTest.swift
+++ b/SwiftChallengesTests/NeetCode/Intervals/MeetingRoomsTest.swift
@@ -1,0 +1,54 @@
+//
+//  MeetingRoomsTest.swift
+//  SwiftChallengesTests
+//
+//  Created by KyleLearnedThis on 7/20/26.
+//
+
+import XCTest
+
+class MeetingRoomsTest: XCTestCase {
+
+    private let sut = MeetingRooms()
+
+    private func verify(_ intervals: [[Int]], _ expected: Bool, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(sut.canAttendMeetings(intervals), expected, file: file, line: line)
+    }
+
+    // MARK: - Base cases
+
+    func testEmpty() {
+        verify([], true)
+    }
+
+    func testSingleMeeting() {
+        verify([[7, 10]], true)
+    }
+
+    // MARK: - LeetCode examples
+
+    func testExample1() {
+        // Overlap between [0,30] and [5,10] -> cannot attend all
+        verify([[0, 30], [5, 10], [15, 20]], false)
+    }
+
+    func testExample2() {
+        // No overlap -> can attend all
+        verify([[7, 10], [2, 4]], true)
+    }
+
+    // MARK: - Edge cases
+
+    func testTouchingEndpointsAllowed() {
+        // One meeting ends exactly when the next begins -> no conflict
+        verify([[1, 5], [5, 10], [10, 15]], true)
+    }
+
+    func testUnsortedWithOverlap() {
+        verify([[10, 20], [2, 6], [4, 9]], false)
+    }
+
+    func testIdenticalMeetings() {
+        verify([[1, 5], [1, 5]], false)
+    }
+}


### PR DESCRIPTION
## Summary
- Add **252. Meeting Rooms** (`canAttendMeetings`) under NeetCode/Intervals.
- Sort intervals by start time, then check adjacent pairs for overlap; touching endpoints don't count as conflicts.
- Registered new `Intervals` group and files in the Xcode project.

## Tests
- Covers empty, single meeting, LeetCode examples, touching endpoints, unsorted-with-overlap, and identical meetings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)